### PR TITLE
#3 Support @inject to enable declaring dependency-injected properties and more 

### DIFF
--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -5,7 +5,6 @@ using RazorSlices.Samples.WebApp.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<LoremService>();
-builder.Services.AddHttpContextAccessor();
 
 var app = builder.Build();
 

--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -1,7 +1,11 @@
 using RazorSlices;
 using RazorSlices.Samples.WebApp;
+using RazorSlices.Samples.WebApp.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<LoremService>();
+builder.Services.AddHttpContextAccessor();
 
 var app = builder.Build();
 
@@ -23,6 +27,8 @@ app.MapGet("/lorem-stream", (HttpContext httpContext) =>
     httpContext.Response.ContentType = "text/html; charset=utf-8";
     return slice.RenderAsync(httpContext.Response.Body);
 });
+app.MapGet("/lorem-injectableproperties", (int? paraCount, int? paraLength, IServiceProvider serviceProvider) =>
+    Results.Extensions.RazorSlice("/Slices/LoremInjectableProperties.cshtml", new LoremParams(paraCount, paraLength), serviceProvider));
 app.MapGet("/unicode", () => Results.Extensions.RazorSlice("/Slices/Unicode.cshtml"));
 app.MapGet("/library", () => Results.Extensions.RazorSlice("/Slices/FromLibrary.cshtml"));
 

--- a/samples/RazorSlices.Samples.WebApp/Services/LoremService.cs
+++ b/samples/RazorSlices.Samples.WebApp/Services/LoremService.cs
@@ -1,4 +1,5 @@
 ﻿using RazorSlices.Samples.WebApp.Slices;
+using System.Text;
 
 namespace RazorSlices.Samples.WebApp.Services;
 
@@ -6,11 +7,11 @@ public class LoremService
 {
     public string Sentences(int length)
     {
-        string sentences = "";
+        var sb = new StringBuilder();
         for (int i = 0; i < length; i++)
         {
-            sentences += PageContent.Sentence;
+            sb.Append(PageContent.Sentence);
         }
-        return sentences;
+        return sb.ToString();
     }
 }

--- a/samples/RazorSlices.Samples.WebApp/Services/LoremService.cs
+++ b/samples/RazorSlices.Samples.WebApp/Services/LoremService.cs
@@ -1,0 +1,16 @@
+﻿using RazorSlices.Samples.WebApp.Slices;
+
+namespace RazorSlices.Samples.WebApp.Services;
+
+public class LoremService
+{
+    public string Sentences(int length)
+    {
+        string sentences = "";
+        for (int i = 0; i < length; i++)
+        {
+            sentences += PageContent.Sentence;
+        }
+        return sentences;
+    }
+}

--- a/samples/RazorSlices.Samples.WebApp/Slices/LoremInjectableProperties.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/LoremInjectableProperties.cshtml
@@ -1,0 +1,41 @@
+﻿@using RazorSlices.Samples.WebApp.Services;
+@inherits RazorSliceHttpResult<LoremParams>
+@inject LoremService loremService
+@inject IHttpContextAccessor contextAccessor
+
+@{
+    string title = "Lorem Ipsum (Dependency-injected properties)";
+}
+
+<!DOCTYPE html>
+<html lang="en" class="h-100">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@title</title>
+    <base href="/" />
+    <link href="lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="css/site.css" rel="stylesheet" />
+    <link rel="icon" href="/docs/5.3/assets/img/favicons/favicon.ico">
+    <link href="css/site.css" rel="stylesheet" />
+</head>
+<body class="d-flex flex-column h-100">
+    <main class="flex-shrink-0">
+        <div class="container">
+            <h1 class="mt-5">@title</h1>
+            <p class="text-success">This Lorem Ipsum sentences was created using dependency-injected properties!</p>
+            <p>@contextAccessor.HttpContext!.Request.Path</p>
+            @for (var i = 0; i < Model.ParagraphCount; i++)
+            {
+                <p>@loremService.Sentences(Model.ParagraphSentenceCount)</p>
+            }
+        </div>
+    </main>
+
+    <footer class="footer mt-auto py-3 bg-light">
+        <div class="container">
+            <a href="https://github.com/DamianEdwards/RazorSlices"><span class="text-muted">RazorSlices</span></a>
+        </div>
+    </footer>
+</body>
+</html>

--- a/samples/RazorSlices.Samples.WebApp/Slices/LoremInjectableProperties.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/LoremInjectableProperties.cshtml
@@ -1,7 +1,6 @@
 ﻿@using RazorSlices.Samples.WebApp.Services;
 @inherits RazorSliceHttpResult<LoremParams>
 @inject LoremService loremService
-@inject IHttpContextAccessor contextAccessor
 
 @{
     string title = "Lorem Ipsum (Dependency-injected properties)";
@@ -24,7 +23,6 @@
         <div class="container">
             <h1 class="mt-5">@title</h1>
             <p class="text-success">This Lorem Ipsum sentences was created using dependency-injected properties!</p>
-            <p>@contextAccessor.HttpContext!.Request.Path</p>
             @for (var i = 0; i < Model.ParagraphCount; i++)
             {
                 <p>@loremService.Sentences(Model.ParagraphSentenceCount)</p>

--- a/src/RazorSlices/HttpResultsExtensions.cs
+++ b/src/RazorSlices/HttpResultsExtensions.cs
@@ -26,7 +26,7 @@ public static class HttpResultsExtensions
     /// </summary>
     /// <param name="resultExtensions">The <see cref="IResultExtensions"/>.</param>
     /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
-    /// <param name="serviceProvider"></param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
     /// <returns>The <see cref="RazorSliceHttpResult" /> instance.</returns>
     public static IResult RazorSlice(
@@ -58,7 +58,7 @@ public static class HttpResultsExtensions
     /// <param name="resultExtensions">The <see cref="IResultExtensions"/>.</param>
     /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
     /// <param name="model">The model to use for the template instance.</param>
-    /// <param name="serviceProvider"></param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
     /// <typeparam name="TModel">The model type of the template.</typeparam>
     /// <returns>The <see cref="RazorSliceHttpResult" /> instance.</returns>

--- a/src/RazorSlices/HttpResultsExtensions.cs
+++ b/src/RazorSlices/HttpResultsExtensions.cs
@@ -26,6 +26,21 @@ public static class HttpResultsExtensions
     /// </summary>
     /// <param name="resultExtensions">The <see cref="IResultExtensions"/>.</param>
     /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
+    /// <param name="serviceProvider"></param>
+    /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
+    /// <returns>The <see cref="RazorSliceHttpResult" /> instance.</returns>
+    public static IResult RazorSlice(
+#pragma warning disable IDE0060 // Remove unused parameter
+        this IResultExtensions resultExtensions,
+#pragma warning restore IDE0060 // Remove unused parameter
+        string sliceName, IServiceProvider serviceProvider, int statusCode = 200) =>
+        RazorSlices.RazorSlice.CreateHttpResult(sliceName, serviceProvider, statusCode);
+
+    /// <summary>
+    /// Creates and returns a new instance of a <see cref="RazorSliceHttpResult" /> based on the provided name.
+    /// </summary>
+    /// <param name="resultExtensions">The <see cref="IResultExtensions"/>.</param>
+    /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
     /// <param name="model">The model to use for the template instance.</param>
     /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
     /// <typeparam name="TModel">The model type of the template.</typeparam>
@@ -36,4 +51,21 @@ public static class HttpResultsExtensions
 #pragma warning restore IDE0060 // Remove unused parameter
         string sliceName, TModel model, int statusCode = 200) =>
         RazorSlices.RazorSlice.CreateHttpResult(sliceName, model, statusCode);
+
+    /// <summary>
+    /// Creates and returns a new instance of a <see cref="RazorSliceHttpResult" /> based on the provided name.
+    /// </summary>
+    /// <param name="resultExtensions">The <see cref="IResultExtensions"/>.</param>
+    /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
+    /// <param name="model">The model to use for the template instance.</param>
+    /// <param name="serviceProvider"></param>
+    /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
+    /// <typeparam name="TModel">The model type of the template.</typeparam>
+    /// <returns>The <see cref="RazorSliceHttpResult" /> instance.</returns>
+    public static IResult RazorSlice<TModel>(
+#pragma warning disable IDE0060 // Remove unused parameter
+        this IResultExtensions resultExtensions,
+#pragma warning restore IDE0060 // Remove unused parameter
+        string sliceName, TModel model, IServiceProvider serviceProvider, int statusCode = 200) =>
+        RazorSlices.RazorSlice.CreateHttpResult(sliceName, model, serviceProvider, statusCode);
 }

--- a/src/RazorSlices/RazorSlice.CreateHttpResult.cs
+++ b/src/RazorSlices/RazorSlice.CreateHttpResult.cs
@@ -22,7 +22,7 @@ public abstract partial class RazorSlice
     /// Creates and returns a new instance of a <see cref="RazorSliceHttpResult" /> based on the provided name.
     /// </summary>
     /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
-    /// <param name="serviceProvider"></param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
     /// <returns>The <see cref="RazorSliceHttpResult" /> instance.</returns>
     public static RazorSliceHttpResult CreateHttpResult(string sliceName, IServiceProvider serviceProvider, int statusCode = StatusCodes.Status200OK)
@@ -65,7 +65,7 @@ public abstract partial class RazorSlice
     /// </summary>
     /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
     /// <param name="model">The model to use for the template instance.</param>
-    /// <param name="serviceProvider"></param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
     /// <typeparam name="TModel">The model type of the template.</typeparam>
     /// <returns>The <see cref="RazorSliceHttpResult{TModel}" /> instance.</returns>

--- a/src/RazorSlices/RazorSlice.CreateHttpResult.cs
+++ b/src/RazorSlices/RazorSlice.CreateHttpResult.cs
@@ -19,6 +19,20 @@ public abstract partial class RazorSlice
     }
 
     /// <summary>
+    /// Creates and returns a new instance of a <see cref="RazorSliceHttpResult" /> based on the provided name.
+    /// </summary>
+    /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
+    /// <param name="serviceProvider"></param>
+    /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
+    /// <returns>The <see cref="RazorSliceHttpResult" /> instance.</returns>
+    public static RazorSliceHttpResult CreateHttpResult(string sliceName, IServiceProvider serviceProvider, int statusCode = StatusCodes.Status200OK)
+    {
+        var result = (RazorSliceHttpResult)Create(ResolveSliceWithServiceFactory(sliceName), serviceProvider);
+        result.StatusCode = statusCode;
+        return result;
+    }
+
+    /// <summary>
     /// Creates and returns a new instance of a <see cref="RazorSliceHttpResult" /> using the provided <see cref="SliceFactory" /> delegate.
     /// </summary>
     /// <param name="sliceFactory">The <see cref="SliceFactory" /> delegate.</param>
@@ -42,6 +56,22 @@ public abstract partial class RazorSlice
     public static RazorSliceHttpResult<TModel> CreateHttpResult<TModel>(string sliceName, TModel model, int statusCode = StatusCodes.Status200OK)
     {
         var result = (RazorSliceHttpResult<TModel>)Create(sliceName, model);
+        result.StatusCode = statusCode;
+        return result;
+    }
+
+    /// <summary>
+    /// Creates and returns a new instance of a <see cref="RazorSliceHttpResult{TModel}" /> based on the provided name.
+    /// </summary>
+    /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
+    /// <param name="model">The model to use for the template instance.</param>
+    /// <param name="serviceProvider"></param>
+    /// <param name="statusCode">The HTTP status code to return. Defaults to <see cref="StatusCodes.Status200OK"/>.</param>
+    /// <typeparam name="TModel">The model type of the template.</typeparam>
+    /// <returns>The <see cref="RazorSliceHttpResult{TModel}" /> instance.</returns>
+    public static RazorSliceHttpResult<TModel> CreateHttpResult<TModel>(string sliceName, TModel model, IServiceProvider serviceProvider, int statusCode = StatusCodes.Status200OK)
+    {
+        var result = (RazorSliceHttpResult<TModel>)Create(ResolveSliceWithServiceFactory<TModel>(sliceName), model, serviceProvider);
         result.StatusCode = statusCode;
         return result;
     }

--- a/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
+++ b/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
@@ -187,14 +187,7 @@ public abstract partial class RazorSlice
             var modelType = modelPropInfo.PropertyType;
             var razorOfModelType = typeof(RazorSlice<>).MakeGenericType(modelType);
 
-            if (injectableProperties.Any())
-            {
-                factoryDelegateType = typeof(SliceWithServiceFactory<>).MakeGenericType(modelType);
-            }
-            else
-            {
-                factoryDelegateType = typeof(SliceFactory<>).MakeGenericType(modelType);
-            }
+            factoryDelegateType = typeof(SliceWithServiceFactory<>).MakeGenericType(modelType);
 
             // Make a SliceWithServiceFactory<TModel> like:
             //
@@ -226,14 +219,7 @@ public abstract partial class RazorSlice
             //     // ...
             //     return slice;
             // }
-            if (injectableProperties.Any())
-            {
-                factoryDelegateType = typeof(SliceWithServiceFactory);
-            }
-            else
-            {
-                factoryDelegateType = typeof(SliceFactory);
-            }
+            factoryDelegateType = typeof(SliceWithServiceFactory);
             expressions.Add(Expression.Label(Expression.Label(typeof(RazorSlice)), sliceVariable));
         }
         

--- a/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
+++ b/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
@@ -400,7 +400,7 @@ public abstract partial class RazorSlice
 
         var sliceDefinition = _slicesByName[sliceName];
 
-        if (sliceDefinition.InjectableProperties.Any())
+        if (sliceDefinition.HasInjectableProperties)
         {
             throw new InvalidOperationException($"{sliceName} has injectable properties but IServiceProvider is not provided");
         }
@@ -429,7 +429,7 @@ public abstract partial class RazorSlice
 
         var sliceDefinition = _slicesByName[sliceName];
 
-        if (sliceDefinition.InjectableProperties.Any())
+        if (sliceDefinition.HasInjectableProperties)
         {
             throw new InvalidOperationException($"{sliceName} has injectable properties but IServiceProvider is not provided");
         }

--- a/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
+++ b/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
@@ -339,7 +339,7 @@ public abstract partial class RazorSlice
     /// Creates an instance of a <see cref="RazorSlice" /> template using the provided <see cref="SliceFactory" /> delegate.
     /// </summary>
     /// <param name="sliceFactory">The <see cref="SliceFactory" /> delegate to create the template with.</param>
-    /// <param name="serviceProvider"></param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <returns>A <see cref="RazorSlice" /> instance for the template.</returns>
     public static RazorSlice Create(SliceWithServicesFactory sliceFactory, IServiceProvider serviceProvider) => sliceFactory(serviceProvider);
 
@@ -366,7 +366,7 @@ public abstract partial class RazorSlice
     /// </summary>
     /// <param name="sliceFactory">The <see cref="SliceFactory" /> delegate to create the template with.</param>
     /// <param name="model">The model to use for the template instance.</param>
-    /// <param name="serviceProvider"></param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <typeparam name="TModel">The model type of the template.</typeparam>
     /// <returns>A <see cref="RazorSlice{TModel}" /> instance for the template.</returns>
     public static RazorSlice<TModel> Create<TModel>(SliceWithServicesFactory<TModel> sliceFactory, TModel model, IServiceProvider serviceProvider) 

--- a/src/RazorSlices/SliceDefinition.cs
+++ b/src/RazorSlices/SliceDefinition.cs
@@ -1,0 +1,49 @@
+﻿using System.Reflection;
+
+namespace RazorSlices;
+
+/// <summary>
+/// A class that contain relevant details about a slice
+/// </summary>
+public class SliceDefinition
+{
+    private readonly string _identifier;
+    private readonly Type _sliceType;
+    private readonly Delegate _factory;
+    private readonly IEnumerable<PropertyInfo> _injectableProperties;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="identifier"></param>
+    /// <param name="sliceType"></param>
+    /// <param name="factory"></param>
+    /// <param name="injectableProperties"></param>
+    public SliceDefinition(string identifier, Type sliceType, Delegate factory, IEnumerable<PropertyInfo> injectableProperties)
+    {
+        _identifier = identifier;
+        _sliceType = sliceType;
+        _factory = factory;
+        _injectableProperties = injectableProperties;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public string Identifier => _identifier;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public Type SliceType => _sliceType;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public Delegate Factory => _factory;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public IEnumerable<PropertyInfo> InjectableProperties => _injectableProperties;
+}

--- a/src/RazorSlices/SliceDefinition.cs
+++ b/src/RazorSlices/SliceDefinition.cs
@@ -3,7 +3,7 @@
 namespace RazorSlices;
 
 /// <summary>
-/// A class that contain relevant details about a slice
+/// A class that contains relevant details about a slice
 /// </summary>
 public class SliceDefinition
 {
@@ -13,37 +13,43 @@ public class SliceDefinition
     private readonly IEnumerable<PropertyInfo> _injectableProperties;
 
     /// <summary>
-    /// 
+    /// Initializes a new instance of the <see cref="SliceDefinition"/> class with the specified identifier, slice type, factory, and injectable properties.
     /// </summary>
-    /// <param name="identifier"></param>
-    /// <param name="sliceType"></param>
-    /// <param name="factory"></param>
-    /// <param name="injectableProperties"></param>
+    /// <param name="identifier">The unique identifier of the slice.</param>
+    /// <param name="sliceType">The type of the slice.</param>
+    /// <param name="factory">The factory delegate used to create instances of the slice.</param>
+    /// <param name="injectableProperties">The properties of the slice that can be injected.</param>
     public SliceDefinition(string identifier, Type sliceType, Delegate factory, IEnumerable<PropertyInfo> injectableProperties)
     {
         _identifier = identifier;
         _sliceType = sliceType;
         _factory = factory;
         _injectableProperties = injectableProperties;
+        HasInjectableProperties = injectableProperties.Any();
     }
 
     /// <summary>
-    /// 
+    /// Gets the unique identifier of the slice.
     /// </summary>
     public string Identifier => _identifier;
 
     /// <summary>
-    /// 
+    /// Gets the type of the slice.
     /// </summary>
     public Type SliceType => _sliceType;
 
     /// <summary>
-    /// 
+    /// Gets the factory delegate used to create instances of the slice.
     /// </summary>
     public Delegate Factory => _factory;
 
     /// <summary>
-    /// 
+    /// Gets the dependency-injected properties of the slice.
     /// </summary>
     public IEnumerable<PropertyInfo> InjectableProperties => _injectableProperties;
+
+    /// <summary>
+    /// Gets a value indicating whether this slice definition has any dependency-injected properties
+    /// </summary>
+    public bool HasInjectableProperties { get; private set; }
 }

--- a/src/RazorSlices/SliceDefinition.cs
+++ b/src/RazorSlices/SliceDefinition.cs
@@ -3,9 +3,9 @@
 namespace RazorSlices;
 
 /// <summary>
-/// A class that contains relevant details about a slice
+/// A class that contains relevant details about a slice.
 /// </summary>
-public class SliceDefinition
+internal sealed class SliceDefinition
 {
     private readonly string _identifier;
     private readonly Type _sliceType;
@@ -19,7 +19,7 @@ public class SliceDefinition
     /// <param name="sliceType">The type of the slice.</param>
     /// <param name="factory">The factory delegate used to create instances of the slice.</param>
     /// <param name="injectableProperties">The properties of the slice that can be injected.</param>
-    public SliceDefinition(string identifier, Type sliceType, Delegate factory, IEnumerable<PropertyInfo> injectableProperties)
+    internal SliceDefinition(string identifier, Type sliceType, Delegate factory, IEnumerable<PropertyInfo> injectableProperties)
     {
         _identifier = identifier;
         _sliceType = sliceType;
@@ -31,25 +31,25 @@ public class SliceDefinition
     /// <summary>
     /// Gets the unique identifier of the slice.
     /// </summary>
-    public string Identifier => _identifier;
+    internal string Identifier => _identifier;
 
     /// <summary>
     /// Gets the type of the slice.
     /// </summary>
-    public Type SliceType => _sliceType;
+    internal Type SliceType => _sliceType;
 
     /// <summary>
     /// Gets the factory delegate used to create instances of the slice.
     /// </summary>
-    public Delegate Factory => _factory;
+    internal Delegate Factory => _factory;
 
     /// <summary>
     /// Gets the dependency-injected properties of the slice.
     /// </summary>
-    public IEnumerable<PropertyInfo> InjectableProperties => _injectableProperties;
+    internal IEnumerable<PropertyInfo> InjectableProperties => _injectableProperties;
 
     /// <summary>
     /// Gets a value indicating whether this slice definition has any dependency-injected properties
     /// </summary>
-    public bool HasInjectableProperties { get; private set; }
+    public bool HasInjectableProperties { get; }
 }

--- a/src/RazorSlices/SliceFactory.cs
+++ b/src/RazorSlices/SliceFactory.cs
@@ -7,7 +7,7 @@
 public delegate RazorSlice SliceFactory();
 
 /// <summary>
-/// A delegate for creating instances of the types generated for .cshtml template files with <c>@inject</c>.
+/// A delegate for creating instances of the types generated for .cshtml template files with <c>@inject</c> properties.
 /// </summary>
 /// <returns>A <see cref="RazorSlice" /> instance.</returns>
 public delegate RazorSlice SliceWithServicesFactory(IServiceProvider serviceProvider);

--- a/src/RazorSlices/SliceFactory.cs
+++ b/src/RazorSlices/SliceFactory.cs
@@ -10,7 +10,7 @@ public delegate RazorSlice SliceFactory();
 /// A delegate for creating instances of the types generated for .cshtml template files.
 /// </summary>
 /// <returns>A <see cref="RazorSlice" /> instance.</returns>
-public delegate RazorSlice SliceWithServiceFactory(IServiceProvider serviceProvider);
+public delegate RazorSlice SliceWithServicesFactory(IServiceProvider serviceProvider);
 
 /// <summary>
 /// A delegate for creating instances of the types generated for .cshtml template files with strongly-typed models.
@@ -22,4 +22,4 @@ public delegate RazorSlice<TModel> SliceFactory<TModel>(TModel model);
 /// A delegate for creating instances of the types generated for .cshtml template files with strongly-typed models.
 /// </summary>
 /// <returns>A <see cref="RazorSlice{TModel}" /> instance.</returns>
-public delegate RazorSlice<TModel> SliceWithServiceFactory<TModel>(TModel model, IServiceProvider serviceProvider);
+public delegate RazorSlice<TModel> SliceWithServicesFactory<TModel>(TModel model, IServiceProvider serviceProvider);

--- a/src/RazorSlices/SliceFactory.cs
+++ b/src/RazorSlices/SliceFactory.cs
@@ -7,7 +7,7 @@
 public delegate RazorSlice SliceFactory();
 
 /// <summary>
-/// A delegate for creating instances of the types generated for .cshtml template files.
+/// A delegate for creating instances of the types generated for .cshtml template files with <c>@inject</c>.
 /// </summary>
 /// <returns>A <see cref="RazorSlice" /> instance.</returns>
 public delegate RazorSlice SliceWithServicesFactory(IServiceProvider serviceProvider);
@@ -19,7 +19,7 @@ public delegate RazorSlice SliceWithServicesFactory(IServiceProvider serviceProv
 public delegate RazorSlice<TModel> SliceFactory<TModel>(TModel model);
 
 /// <summary>
-/// A delegate for creating instances of the types generated for .cshtml template files with strongly-typed models.
+/// A delegate for creating instances of the types generated for .cshtml template files with strongly-typed models and <c>@inject</c> properties.
 /// </summary>
 /// <returns>A <see cref="RazorSlice{TModel}" /> instance.</returns>
 public delegate RazorSlice<TModel> SliceWithServicesFactory<TModel>(TModel model, IServiceProvider serviceProvider);

--- a/src/RazorSlices/SliceFactory.cs
+++ b/src/RazorSlices/SliceFactory.cs
@@ -6,9 +6,20 @@
 /// <returns>A <see cref="RazorSlice" /> instance.</returns>
 public delegate RazorSlice SliceFactory();
 
+/// <summary>
+/// A delegate for creating instances of the types generated for .cshtml template files.
+/// </summary>
+/// <returns>A <see cref="RazorSlice" /> instance.</returns>
+public delegate RazorSlice SliceWithServiceFactory(IServiceProvider serviceProvider);
 
 /// <summary>
 /// A delegate for creating instances of the types generated for .cshtml template files with strongly-typed models.
 /// </summary>
 /// <returns>A <see cref="RazorSlice{TModel}" /> instance.</returns>
 public delegate RazorSlice<TModel> SliceFactory<TModel>(TModel model);
+
+/// <summary>
+/// A delegate for creating instances of the types generated for .cshtml template files with strongly-typed models.
+/// </summary>
+/// <returns>A <see cref="RazorSlice{TModel}" /> instance.</returns>
+public delegate RazorSlice<TModel> SliceWithServiceFactory<TModel>(TModel model, IServiceProvider serviceProvider);


### PR DESCRIPTION
Regarding the first suggestions from #3. I have made the following changes to the code:

- Created a new class called `SliceDefinition` to store relevant details such as string identifier, slice Type, Delegate sliceFactory, and injectable property details. I'm considering storing the `PropertyInfo` of the injectable properties in the `SliceDefinition` class.

- Refactored `RazorSlice.ResolveAndCreate` to utilise the newly created `SliceDefinition` class.

```cs
private static readonly ReadOnlyDictionary<string, SliceDefinition> _slicesByName;
private static readonly ReadOnlyDictionary<Type, SliceDefinition> _slicesByType;
```

I'm still getting familiar with the codebase, so please let me know if I missed anything or if there's a better way to do something. 

I will keep working on this pull request. 
