### PR TITLE
Add support for rendering slices to a StringBuilder and more

### DIFF
--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -1,6 +1,7 @@
 using RazorSlices;
 using RazorSlices.Samples.WebApp;
 using RazorSlices.Samples.WebApp.Services;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +31,19 @@ app.MapGet("/lorem-injectableproperties", (int? paraCount, int? paraLength, ISer
     Results.Extensions.RazorSlice("/Slices/LoremInjectableProperties.cshtml", new LoremParams(paraCount, paraLength), serviceProvider));
 app.MapGet("/unicode", () => Results.Extensions.RazorSlice("/Slices/Unicode.cshtml"));
 app.MapGet("/library", () => Results.Extensions.RazorSlice("/Slices/FromLibrary.cshtml"));
+app.MapGet("/render-to-string", () =>
+{
+    var slice = RazorSlice.Create("/Slices/LoremFormattable.cshtml", new LoremParams(1, 4));
+    string template = slice.Render();
+    return Results.Ok(new { HtmlString = template });
+});
+app.MapGet("/render-to-stringbuilder", async (IServiceProvider serviceProvider) =>
+{
+    var stringBuilder = new StringBuilder();
+    var slice = RazorSlice.Create(RazorSlice.ResolveSliceWithServiceFactory<LoremParams>("/Slices/LoremInjectableProperties.cshtml"), new LoremParams(1, 4), serviceProvider);
+    await slice.RenderAsync(stringBuilder);
+    return Results.Ok(new { HtmlString = stringBuilder.ToString() });
+});
 
 app.MapGet("/", () => Results.Extensions.RazorSlice("/Slices/Todos.cshtml", Todos.AllTodos));
 app.MapGet("/{id:int}", (int id) =>

--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -40,7 +40,7 @@ app.MapGet("/render-to-string", async () =>
 app.MapGet("/render-to-stringbuilder", async (IServiceProvider serviceProvider) =>
 {
     var stringBuilder = new StringBuilder();
-    var slice = RazorSlice.Create(RazorSlice.ResolveSliceWithServiceFactory<LoremParams>("/Slices/LoremInjectableProperties.cshtml"), new LoremParams(1, 4), serviceProvider);
+    var slice = RazorSlice.Create("/Slices/LoremInjectableProperties.cshtml", new LoremParams(1, 4), serviceProvider);
     await slice.RenderAsync(stringBuilder);
     return Results.Ok(new { HtmlString = stringBuilder.ToString() });
 });

--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -31,10 +31,10 @@ app.MapGet("/lorem-injectableproperties", (int? paraCount, int? paraLength, ISer
     Results.Extensions.RazorSlice("/Slices/LoremInjectableProperties.cshtml", new LoremParams(paraCount, paraLength), serviceProvider));
 app.MapGet("/unicode", () => Results.Extensions.RazorSlice("/Slices/Unicode.cshtml"));
 app.MapGet("/library", () => Results.Extensions.RazorSlice("/Slices/FromLibrary.cshtml"));
-app.MapGet("/render-to-string", () =>
+app.MapGet("/render-to-string", async () =>
 {
     var slice = RazorSlice.Create("/Slices/LoremFormattable.cshtml", new LoremParams(1, 4));
-    string template = slice.Render();
+    var template = await slice.RenderAsync();
     return Results.Ok(new { HtmlString = template });
 });
 app.MapGet("/render-to-stringbuilder", async (IServiceProvider serviceProvider) =>

--- a/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
+++ b/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
@@ -277,7 +277,7 @@ public abstract partial class RazorSlice
     public static SliceFactory ResolveSliceFactory(string sliceName) => ResolveSliceFactoryImpl(sliceName);
 
     /// <summary>
-    /// Resolves a <see cref="SliceFactory" /> delegate for the provided template name.
+    /// Resolves a <see cref="SliceWithServicesFactory" /> delegate for the provided template name.
     /// </summary>
     /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
     /// <returns>The <see cref="SliceWithServicesFactory" /> delegate that can be used to create instances of the template.</returns>
@@ -292,7 +292,7 @@ public abstract partial class RazorSlice
     public static SliceFactory<TModel> ResolveSliceFactory<TModel>(string sliceName) => ResolveSliceFactoryImpl<TModel>(sliceName);
 
     /// <summary>
-    /// Resolves a <see cref="SliceFactory{TModel}" /> delegate for the provided template name with a typed model.
+    /// Resolves a <see cref="SliceWithServicesFactory{TModel}" /> delegate for the provided template name with a typed model.
     /// </summary>
     /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
     /// <typeparam name="TModel">The template model type.</typeparam>
@@ -336,9 +336,9 @@ public abstract partial class RazorSlice
     public static RazorSlice Create(SliceFactory sliceFactory) => sliceFactory();
 
     /// <summary>
-    /// Creates an instance of a <see cref="RazorSlice" /> template using the provided <see cref="SliceFactory" /> delegate.
+    /// Creates an instance of a <see cref="RazorSlice" /> template using the provided <see cref="SliceWithServicesFactory" /> delegate.
     /// </summary>
-    /// <param name="sliceFactory">The <see cref="SliceFactory" /> delegate to create the template with.</param>
+    /// <param name="sliceFactory">The <see cref="SliceWithServicesFactory" /> delegate to create the template with.</param>
     /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <returns>A <see cref="RazorSlice" /> instance for the template.</returns>
     public static RazorSlice Create(SliceWithServicesFactory sliceFactory, IServiceProvider serviceProvider) => sliceFactory(serviceProvider);
@@ -362,9 +362,9 @@ public abstract partial class RazorSlice
     public static RazorSlice<TModel> Create<TModel>(SliceFactory<TModel> sliceFactory, TModel model) => sliceFactory(model);
 
     /// <summary>
-    /// Creates an instance of a <see cref="RazorSlice" /> template using the provided <see cref="SliceFactory" /> delegate with a typed model.
+    /// Creates an instance of a <see cref="RazorSlice" /> template using the provided <see cref="SliceWithServicesFactory{TModel}" /> delegate with a typed model.
     /// </summary>
-    /// <param name="sliceFactory">The <see cref="SliceFactory" /> delegate to create the template with.</param>
+    /// <param name="sliceFactory">The <see cref="SliceWithServicesFactory{TModel}" /> delegate to create the template with.</param>
     /// <param name="model">The model to use for the template instance.</param>
     /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
     /// <typeparam name="TModel">The model type of the template.</typeparam>

--- a/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
+++ b/src/RazorSlices/RazorSlice.ResolveAndCreate.cs
@@ -329,6 +329,18 @@ public abstract partial class RazorSlice
     public static RazorSlice Create(string sliceName) => Create(ResolveSliceFactory(sliceName));
 
     /// <summary>
+    /// Creates an instance of a <see cref="RazorSlice" /> template for the provided template name.
+    /// </summary>
+    /// <remarks>
+    /// Note that this method incurs a lookup cost each time it's invoked. If avoiding that cost is desirable consider using <see cref="ResolveSliceWithServiceFactory(string)" />
+    /// to resolve the template creation delegate once and then use <see cref="Create(SliceWithServicesFactory, IServiceProvider)" /> each time a template instance is required.
+    /// </remarks>
+    /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
+    /// <returns>A <see cref="RazorSlice" /> instance for the template.</returns>
+    public static RazorSlice Create(string sliceName, IServiceProvider serviceProvider) => Create(ResolveSliceWithServiceFactory(sliceName), serviceProvider);
+
+    /// <summary>
     /// Creates an instance of a <see cref="RazorSlice" /> template using the provided <see cref="SliceFactory" /> delegate.
     /// </summary>
     /// <param name="sliceFactory">The <see cref="SliceFactory" /> delegate to create the template with.</param>
@@ -351,6 +363,20 @@ public abstract partial class RazorSlice
     /// <typeparam name="TModel">The model type of the template.</typeparam>
     /// <returns>A <see cref="RazorSlice{TModel}" /> instance for the template.</returns>
     public static RazorSlice<TModel> Create<TModel>(string sliceName, TModel model) => Create(ResolveSliceFactory<TModel>(sliceName), model);
+
+    /// <summary>
+    /// Creates an instance of a <see cref="RazorSlice" /> template for the provided template name with a typed model.
+    /// </summary>
+    /// <remarks>
+    /// Note that this method incurs a lookup cost each time it's invoked. If avoiding that cost is desirable consider using <see cref="ResolveSliceWithServiceFactory{TModel}(string)" />
+    /// to resolve the template creation delegate once and then use <see cref="Create{TModel}(SliceWithServicesFactory{TModel}, TModel, IServiceProvider)" /> each time a template instance is required.
+    /// </remarks>
+    /// <param name="sliceName">The project-relative path to the template .cshtml file, e.g. /Slices/MyTemplate.cshtml<c></c></param>
+    /// <param name="model">The model to use for the template instance.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> to use when setting the template's <c>@inject</c> properties.</param>
+    /// <typeparam name="TModel">The model type of the template.</typeparam>
+    /// <returns>A <see cref="RazorSlice{TModel}" /> instance for the template.</returns>
+    public static RazorSlice<TModel> Create<TModel>(string sliceName, TModel model, IServiceProvider serviceProvider) => Create(ResolveSliceWithServiceFactory<TModel>(sliceName), model, serviceProvider);
 
     /// <summary>
     /// Creates an instance of a <see cref="RazorSlice" /> template using the provided <see cref="SliceFactory" /> delegate with a typed model.

--- a/src/RazorSlices/RazorSlice.StringBuilderExtensions.cs
+++ b/src/RazorSlices/RazorSlice.StringBuilderExtensions.cs
@@ -34,6 +34,7 @@ public static class RazorSliceStringBuilderExtensions
 
         if (task.IsCompletedSuccessfully)
         {
+            task.GetAwaiter().GetResult();
             return ValueTask.FromResult(sb.ToString());
         }
 

--- a/src/RazorSlices/RazorSlice.StringBuilderExtensions.cs
+++ b/src/RazorSlices/RazorSlice.StringBuilderExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System.Text;
+using System.Text.Encodings.Web;
+
+namespace RazorSlices;
+
+/// <summary>
+/// Extension methods for <see cref="RazorSlice" /> that allow rendering to a <see cref="StringBuilder" /> or string.
+/// </summary>
+public static class RazorSliceStringBuilderExtensions
+{
+    /// <summary>
+    /// Renders the template to the specified <see cref="StringBuilder"/>.
+    /// </summary>
+    /// <param name="slice">The <see cref="RazorSlice" /> instance.</param>
+    /// <param name="stringBuilder">The <see cref="StringBuilder"/> to render the template to.</param>
+    /// <param name="htmlEncoder">An optional <see cref="HtmlEncoder"/> instance to use when rendering the template. If none is specified, <see cref="HtmlEncoder.Default"/> will be used.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the rendering of the template.</returns>
+    public static ValueTask RenderAsync(this RazorSlice slice, StringBuilder stringBuilder, HtmlEncoder? htmlEncoder = null)
+    {
+        using var stringWriter = new StringWriter(stringBuilder);
+        return slice.RenderAsync(stringWriter, htmlEncoder);
+    }
+
+    /// <summary>
+    /// Renders the template to a string.
+    /// </summary>
+    /// <param name="slice">The <see cref="RazorSlice" /> instance.</param>
+    /// <param name="htmlEncoder">An optional <see cref="HtmlEncoder"/> instance to use when rendering the template. If none is specified, <see cref="HtmlEncoder.Default"/> will be used.</param>
+    /// <returns>A string of the template.</returns>
+    public static string Render(this RazorSlice slice, HtmlEncoder? htmlEncoder = null)
+    {
+        var sb = new StringBuilder();
+        var task = slice.RenderAsync(sb, htmlEncoder);
+
+        if (task.IsCompletedSuccessfully)
+        {
+            task.GetAwaiter().GetResult();
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/RazorSlices/RazorSlice.StringBuilderExtensions.cs
+++ b/src/RazorSlices/RazorSlice.StringBuilderExtensions.cs
@@ -26,17 +26,23 @@ public static class RazorSliceStringBuilderExtensions
     /// </summary>
     /// <param name="slice">The <see cref="RazorSlice" /> instance.</param>
     /// <param name="htmlEncoder">An optional <see cref="HtmlEncoder"/> instance to use when rendering the template. If none is specified, <see cref="HtmlEncoder.Default"/> will be used.</param>
-    /// <returns>A string of the template.</returns>
-    public static string Render(this RazorSlice slice, HtmlEncoder? htmlEncoder = null)
+    /// <returns>The template rendered to a <see cref="string"/>.</returns>
+    public static ValueTask<string> RenderAsync(this RazorSlice slice, HtmlEncoder? htmlEncoder = null)
     {
         var sb = new StringBuilder();
         var task = slice.RenderAsync(sb, htmlEncoder);
 
         if (task.IsCompletedSuccessfully)
         {
-            task.GetAwaiter().GetResult();
+            return ValueTask.FromResult(sb.ToString());
         }
 
+        return AwaitRenderTask(task, sb);
+    }
+
+    private static async ValueTask<string> AwaitRenderTask(ValueTask task, StringBuilder sb)
+    {
+        await task;
         return sb.ToString();
     }
 }


### PR DESCRIPTION
I have made the following changes to the code:
- Added a static class that contains extension methods for rendering slices to a StringBuilder.
- Fixed some documentation comments in `RazorSlice.ResolveAndCreate`
- Added samples 

I named the static class `RazorSliceStringBuilderExtensions`.

## Usage

### Render to a StringBuilder
```cs
RazorSlice slice = RazorSlice.Create("/Slices/LoremStatic.cshtml");
var sb = new StringBuilder();
await slice.RenderAsync(sb);
var template = sb.ToString();
```

### Render to a string
```cs
RazorSlice slice = RazorSlice.Create("/Slices/LoremStatic.cshtml");
string template = await slice.RenderAsync();
```

I believe that with the introduction of these extensions, we will need to make the process of creating a slice easier, particularly for slices that have dependency-injected properties.

Currently, there is no overload that accepts both a string parameter for the slice name and an IServiceProvider. We could consider adding the following methods to address this:

```cs
public static RazorSlice Create(string sliceName, IServiceProvider serviceProvider);
public static RazorSlice<TModel> Create<TModel>(string sliceName, TModel model, IServiceProvider serviceProvider);
```

These methods incur a lookup cost each time they're invoked, which may affect performance. Given this, should we still consider adding them?
