### PR TITLE
Support templated Razor delegates

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ The library is still new and features are being actively added.
     @tmpl(DateTime.Now)
     ```
 
-    > [!IMPORTANT]
-    > Async templated Razor delegates are **NOT** supported and will throw an exception at runtime.
+    **NOTE: Async templated Razor delegates are *NOT* supported and will throw an exception at runtime**
 
 - DI-activated properties via `@inject`
 - Rendering slices from slices (aka partials) via `@(await RenderPartialAsync<MyPartial>())`
@@ -196,7 +195,7 @@ The library is still new and features are being actively added.
       }
       ```
 
-    **Note: The `@section` directive is not supported as it's incompatible with the rendering approach of Razor Slices**
+    **NOTE: The `@section` directive is not supported as it's incompatible with the rendering approach of Razor Slices**
 
 - Asynchronous rendering, i.e. the template can contain `await` statements, e.g. `@await WriteTheThing()`
 - Writing UTF8 `byte[]` values directly to the output

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The library is still new and features are being actively added.
   - [Looping](https://learn.microsoft.com/aspnet/core/mvc/views/razor#looping-for-foreach-while-and-do-while), e.g. `@for`, `@foreach`, `@while`, `@do`
   - [Code blocks](https://learn.microsoft.com/aspnet/core/mvc/views/razor#razor-code-blocks), e.g. `@{ var someThing = someOtherThing; }`
   - [Conditional attribute rendering](https://learn.microsoft.com/aspnet/core/mvc/views/razor#conditional-attribute-rendering)
-  - Functions, e.g.
+  - [Functions](https://learn.microsoft.com/aspnet/core/mvc/views/razor#functions):
 
     ```cshtml
     @functions {
@@ -109,8 +109,8 @@ The library is still new and features are being actively added.
         private int DoAThing() => 123;
     }
     ```
-  
-  - [Templated Razor delegates](https://learn.microsoft.com/aspnet/core/mvc/views/razor#templated-razor-delegates), e.g.
+
+  - [Templated Razor methods](https://learn.microsoft.com/aspnet/core/mvc/views/razor#code-try-48), e.g.
 
     ```cshtml
     @inherits RazorSlice<Todo>
@@ -125,6 +125,23 @@ The library is still new and features are being actively added.
         }
     }
     ```
+
+  - [Templated Razor delegates](https://learn.microsoft.com/aspnet/core/mvc/views/razor#templated-razor-delegates), e.g.
+
+    ```cshtml
+    @inherits RazorSlice<Todo>
+
+    @{
+        var tmpl = @<div>
+            This is a templated Razor delegate. The following value was passed in: @item
+        </div>;
+    }
+
+    @tmpl(DateTime.Now)
+    ```
+
+    > [!IMPORTANT]
+    > Async templated Razor delegates are **NOT** supported and will throw an exception at runtime.
 
 - DI-activated properties via `@inject`
 - Rendering slices from slices (aka partials) via `@(await RenderPartialAsync<MyPartial>())`

--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -41,7 +41,7 @@ app.MapGet("/lorem-stream", async (HttpResponse httpResponse) =>
 });
 app.MapGet("/encoding", () => Results.Extensions.RazorSlice<Slices.Encoding>());
 app.MapGet("/unicode", () => Results.Extensions.RazorSlice<Slices.Unicode>());
-app.MapGet("/templated", () => Results.Extensions.RazorSlice<Slices.Templated>());
+app.MapGet("/templated", (bool async = false) => Results.Extensions.RazorSlice<Slices.Templated, bool>(async));
 app.MapGet("/library", () => Results.Extensions.RazorSlice<LibrarySlices.FromLibrary>());
 app.MapGet("/render-to-string", async () =>
 {

--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -41,6 +41,7 @@ app.MapGet("/lorem-stream", async (HttpResponse httpResponse) =>
 });
 app.MapGet("/encoding", () => Results.Extensions.RazorSlice<Slices.Encoding>());
 app.MapGet("/unicode", () => Results.Extensions.RazorSlice<Slices.Unicode>());
+app.MapGet("/templated", () => Results.Extensions.RazorSlice<Slices.Templated>());
 app.MapGet("/library", () => Results.Extensions.RazorSlice<LibrarySlices.FromLibrary>());
 app.MapGet("/render-to-string", async () =>
 {

--- a/samples/RazorSlices.Samples.WebApp/Slices/Templated.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/Templated.cshtml
@@ -1,0 +1,58 @@
+﻿@using Microsoft.AspNetCore.Html
+@using Microsoft.AspNetCore.Mvc.Razor
+
+@inherits RazorSliceHttpResult
+@implements IUsesLayout<_Layout, LayoutModel>
+
+@{
+    Func<object, HelperResult> tmpl = @<p>
+        Hello from a templated Razor delegate! The following value was passed in: @item
+    </p>;
+    Func<object, HelperResult> asyncTmpl = @<p>
+        @{await Task.Delay(16);}
+        Hello from an async templated Razor delegate! The following value was passed in: @item
+    </p>;
+}
+
+<h1 class="mt-5">@Title()</h1>
+
+<div>
+    <p>This is from the page. What follows is from rendering the templated delegate declared on this page:</p>
+    <div>
+        @tmpl(DateTime.Now)
+    </div>
+</div>
+
+<div>
+    <p>This is from the page. What follows is from rendering the async templated delegate declared on this page:</p>
+    <div>
+        @asyncTmpl(DateTime.Now)
+    </div>
+</div>
+
+@await RenderPartialAsync(_TemplatedPartial.Create(tmpl))
+
+@await RenderPartialAsync(_TemplatedPartial.Create(asyncTmpl))
+
+@functions {
+    public LayoutModel LayoutModel => new() { Title = Title() };
+
+    static string Title() => "Templated Razor Delegates";
+
+    private IHtmlContent Content()
+    {
+        <div>
+
+        </div>
+        return HtmlString.Empty;
+    }
+
+    private async Task<IHtmlContent> AsyncContent()
+    {
+        await Task.Delay(16);
+        <div>
+
+        </div>
+        return HtmlString.Empty;
+    }
+}

--- a/samples/RazorSlices.Samples.WebApp/Slices/Templated.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/Templated.cshtml
@@ -12,7 +12,7 @@
         </p>
         :
         @<p>
-            @{await Task.Delay(16);}
+            @{await Task.Yield();}
             Hello from an async templated Razor delegate! The following value was passed in: @item
         </p>;
 }

--- a/samples/RazorSlices.Samples.WebApp/Slices/Templated.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/Templated.cshtml
@@ -1,58 +1,90 @@
 ﻿@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Mvc.Razor
 
-@inherits RazorSliceHttpResult
+@inherits RazorSliceHttpResult<bool>
 @implements IUsesLayout<_Layout, LayoutModel>
 
 @{
-    Func<object, HelperResult> tmpl = @<p>
-        Hello from a templated Razor delegate! The following value was passed in: @item
-    </p>;
-    Func<object, HelperResult> asyncTmpl = @<p>
-        @{await Task.Delay(16);}
-        Hello from an async templated Razor delegate! The following value was passed in: @item
-    </p>;
+    var async = Model;
+    Func<object, HelperResult> tmpl = !async ?
+        @<p>
+            Hello from a templated Razor delegate! The following value was passed in: @item
+        </p>
+        :
+        @<p>
+            @{await Task.Delay(16);}
+            Hello from an async templated Razor delegate! The following value was passed in: @item
+        </p>;
 }
 
 <h1 class="mt-5">@Title()</h1>
 
-<div>
-    <p>This is from the page. What follows is from rendering the templated delegate declared on this page:</p>
-    <div>
-        @tmpl(DateTime.Now)
+<div class="list-group">
+    <div class="list-group-item">
+        <p>This is from the page. What follows is from rendering the templated delegate declared on this slice:</p>
+        <figure>
+            <blockquote class="blockquote">
+                @tmpl(DateTime.Now)
+            </blockquote>
+            <figcaption class="blockquote-footer">
+                Rendered by the templated delegate
+            </figcaption>
+        </figure>
+    </div>
+    <div class="list-group-item">
+        <p>This is from the page. What follows is from rendering a templated method declared in the <code>@@functions</code> block on this slice:</p>
+        <figure>
+            <blockquote class="blockquote">
+                @if (!async)
+                {
+                    @Content(DateTime.Now)
+                }
+                else
+                {
+                    @await AsyncContent(DateTime.Now)
+                }
+            </blockquote>
+            <figcaption class="blockquote-footer">
+                Rendered by the templated method
+            </figcaption>
+        </figure>
+    </div>
+    <div class="list-group-item">
+        <p>This is from the page. What follows is from rendering a partial that has a templated delegated passed in as the model:</p>
+        <figure>
+            <blockquote class="blockquote">
+                @await RenderPartialAsync(_TemplatedPartial.Create(tmpl))
+            </blockquote>
+            <figcaption class="blockquote-footer">
+                Rendered by the partial
+            </figcaption>
+        </figure>
     </div>
 </div>
-
-<div>
-    <p>This is from the page. What follows is from rendering the async templated delegate declared on this page:</p>
-    <div>
-        @asyncTmpl(DateTime.Now)
-    </div>
-</div>
-
-@await RenderPartialAsync(_TemplatedPartial.Create(tmpl))
-
-@await RenderPartialAsync(_TemplatedPartial.Create(asyncTmpl))
 
 @functions {
     public LayoutModel LayoutModel => new() { Title = Title() };
 
-    static string Title() => "Templated Razor Delegates";
+    static string Title() => "Templated Razor Delegates/Methods";
 
-    private IHtmlContent Content()
+    private IHtmlContent Content<T>(T item)
     {
         <div>
-
+            Hello from a templated method! The following value was passed in: @item
         </div>
+
+        // Returning HtmlContent.Empty makes it possible to call this using a Razor expression instead of a block
         return HtmlString.Empty;
     }
 
-    private async Task<IHtmlContent> AsyncContent()
+    private async Task<IHtmlContent> AsyncContent<T>(T item)
     {
         await Task.Delay(16);
         <div>
-
+            Hello from a templated async method! The following value was passed in: @item
         </div>
+
+        // Returning HtmlContent.Empty makes it possible to call this using a Razor expression instead of a block
         return HtmlString.Empty;
     }
 }

--- a/samples/RazorSlices.Samples.WebApp/Slices/_FooterLinks.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/_FooterLinks.cshtml
@@ -1,6 +1,7 @@
 ﻿<!-- _FooterLinks.cshtml -->
 <a href="/"><span class="text-muted">Home</span></a> |
 <a href="/lorem"><span class="text-muted">Lorem</span></a> |
+<a href="/templated"><span class="text-muted">Templated</span></a> |
 <a href="/encoding"><span class="text-muted">Encoding</span></a> |
 <a href="/unicode"><span class="text-muted">Unicode</span></a> |
 <a href="/render-to-string"><span class="text-muted">Render to string</span></a> |

--- a/samples/RazorSlices.Samples.WebApp/Slices/_TemplatedPartial.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/_TemplatedPartial.cshtml
@@ -1,0 +1,8 @@
+﻿@using Microsoft.AspNetCore.Mvc.Razor
+@inherits RazorSlice<Func<object?, HelperResult>>
+<div>
+    <p>This is from a partial with a templated model. What follows is from the templated delegate passed in as the model:</p>
+    <div style="border: 1px solid silver; padding: 1em">
+        @Model(DateTime.Now)
+    </div>
+</div>

--- a/samples/RazorSlices.Samples.WebApp/Slices/_TemplatedPartial.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/_TemplatedPartial.cshtml
@@ -2,7 +2,12 @@
 @inherits RazorSlice<Func<object?, HelperResult>>
 <div>
     <p>This is from a partial with a templated model. What follows is from the templated delegate passed in as the model:</p>
-    <div style="border: 1px solid silver; padding: 1em">
-        @Model(DateTime.Now)
-    </div>
+    <figure>
+        <blockquote class="blockquote">
+            @Model(DateTime.Now)
+        </blockquote>
+        <figcaption class="blockquote-footer">
+            Rendered by the templated delegate
+        </figcaption>
+    </figure>
 </div>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.8.2</VersionPrefix>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/RazorSlices/IUsesLayout.cs
+++ b/src/RazorSlices/IUsesLayout.cs
@@ -24,7 +24,7 @@ public interface IUsesLayout
 /// Use this interface to specify the layout type for a Razor Slice, e.g:
 /// <example>
 /// <code>
-/// @inherits IUseLayout&lt;_Layout[]&gt;
+/// @implements IUseLayout&lt;_Layout[]&gt;
 /// </code>
 /// </example>
 /// </remarks>
@@ -47,7 +47,7 @@ public interface IUsesLayout<TLayout> : IUsesLayout
 /// Use this interface to specify the layout type for a Razor Slice, e.g:
 /// <example>
 /// <code>
-/// @inherits IUseLayout&lt;_Layout[], LayoutModel&gt;
+/// @implements IUseLayout&lt;_Layout[], LayoutModel&gt;
 /// </code>
 /// </example>
 /// </remarks>

--- a/src/RazorSlices/RazorSlice.Partials.cs
+++ b/src/RazorSlices/RazorSlice.Partials.cs
@@ -72,7 +72,7 @@ public partial class RazorSlice
 
     internal ValueTask<HtmlString> RenderChildSliceAsync(RazorSlice child)
     {
-        Debug.WriteLine($"Rendering child slice of type '{child.GetType().Name}' from layout slice of type '{GetType().Name}'");
+        Debug.WriteLine($"Rendering child slice of type '{child.GetType().Name}' from parent slice of type '{GetType().Name}'");
 
         CopySliceState(this, child);
 

--- a/src/RazorSlices/RazorSlice.cs
+++ b/src/RazorSlices/RazorSlice.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
-using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
@@ -27,7 +26,6 @@ public abstract partial class RazorSlice : IDisposable
     private HtmlEncoder _htmlEncoder = HtmlEncoder.Default;
     private PipeWriter? _pipeWriter;
     private TextWriter? _textWriter;
-    private Utf8PipeTextWriter? _utf8BufferTextWriter;
     private bool _disposed;
 
     /// <summary>
@@ -342,15 +340,6 @@ public abstract partial class RazorSlice : IDisposable
         return HtmlString.Empty;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ReturnPooledObjects()
-    {
-        if (_utf8BufferTextWriter is not null)
-        {
-            Utf8PipeTextWriter.Return(_utf8BufferTextWriter);
-        }
-    }
-
     /// <summary>
     /// Disposes the instance. Overriding implementations should ensure they call <c>base.Dispose()</c> after performing their
     /// custom dispose logic, e.g.:
@@ -382,8 +371,6 @@ public abstract partial class RazorSlice : IDisposable
             Debug.WriteLine($"Disposing content slice of type '{contentSlice.GetType().Name}'");
             contentSlice.Dispose();
         }
-        
-        ReturnPooledObjects();
 
         _disposed = true;
 

--- a/src/RazorSlices/RazorSlice.cs
+++ b/src/RazorSlices/RazorSlice.cs
@@ -20,6 +20,9 @@ public abstract partial class RazorSlice : IDisposable
 
     private static readonly FlushResult _noFlushResult = new(false, false);
 
+    // Used to support nested writers emitted by the Razor compiler when using templated razor delegates
+    private Stack<(PipeWriter?, TextWriter?)>? _writerStack;
+
     private IServiceProvider? _serviceProvider;
     private HtmlEncoder _htmlEncoder = HtmlEncoder.Default;
     private PipeWriter? _pipeWriter;
@@ -77,6 +80,42 @@ public abstract partial class RazorSlice : IDisposable
         }
 
         return ExecuteAsync();
+    }
+
+    /// <summary>
+    /// Puts a text writer on the stack.
+    /// </summary>
+    /// <remarks>
+    /// This method should not be interacted with directly. It's used by the Razor Slices infrastructure.
+    /// </remarks>
+    /// <param name="writer"></param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected void PushWriter(TextWriter writer)
+    {
+        Debug.WriteLine($"Pushing current writers to stack. Now rendering to passed {writer.GetType().Name}.");
+
+        _writerStack ??= new();
+        _writerStack.Push((_pipeWriter, _textWriter));
+
+        _textWriter = writer;
+        _pipeWriter = null;
+    }
+
+    /// <summary>
+    /// Retrieves a text writer from the stack.
+    /// </summary>
+    /// <remarks>
+    /// This method should not be interacted with directly. It's used by the Razor Slices infrastructure.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected void PopWriter()
+    {
+        Debug.Assert(_writerStack is not null, "No writer to pop from the stack. PushWriter should have been called first.");
+        Debug.Assert(_textWriter is not null, $"{nameof(_textWriter)} should not be null!");
+        Debug.Assert(_pipeWriter is null, $"{nameof(_pipeWriter)} should be null!");
+
+        (_pipeWriter, _textWriter) = _writerStack.Pop();
+        Debug.WriteLine($"Popping previous writers off stack. Now rendering to {(_pipeWriter is not null ? "PipeWriter" : "TextWriter")}.");
     }
 
     /// <summary>

--- a/tests/RazorSlices.Samples.WebApp.Tests/WebAppTests.cs
+++ b/tests/RazorSlices.Samples.WebApp.Tests/WebAppTests.cs
@@ -27,6 +27,7 @@ public class WebAppTests
         ["/1", "Wash the dishes", MediaTypeNames.Text.Html],
         ["/encoding", "{&#x27;antiForgery&#x27;", MediaTypeNames.Text.Html],
         ["/unicode", "🐻", MediaTypeNames.Text.Html],
+        ["/templated", "This is from a partial with a templated model", MediaTypeNames.Text.Html],
         ["/library", "This slice was loaded from a referenced Razor Class Library!", MediaTypeNames.Text.Html],
         ["/render-to-string", "htmlString", MediaTypeNames.Application.Json],
         ["/render-to-stringbuilder", "htmlString", MediaTypeNames.Application.Json],


### PR DESCRIPTION
This adds actual support for templated Razor delegates. What I was referring to as *templated Razor delegates* before were actually *templated Razor **methods*** which are different. Razor Slices now supports both forms.

Note that templated Razor delegates that return tasks that look like they come from an async/await method are explicitly **not** supported and will cause a runtime exception.

Fixes #65