### PR TITLE
Fix bug using injectable properties from ExecuteSectionAsync

### DIFF
--- a/samples/RazorSlices.Samples.WebApp/Slices/Lorem/LoremInjectableProperties.cshtml
+++ b/samples/RazorSlices.Samples.WebApp/Slices/Lorem/LoremInjectableProperties.cshtml
@@ -17,7 +17,7 @@
     {
         if (name == "lorem-header")
         {
-            <p class="text-info">This page renders lorem ipsum content from a service that's injected vie the <code>@@inject</code> directive.</p>
+            <p class="text-info">This page renders lorem ipsum content from a service (@LoremService.GetType().Name) that's injected via the <code>@@inject</code> directive.</p>
         }
 
         return Task.CompletedTask;

--- a/src/RazorSlices/RazorLayoutSlice.cs
+++ b/src/RazorSlices/RazorLayoutSlice.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Html;
+﻿using System.Diagnostics;
+using Microsoft.AspNetCore.Html;
 
 namespace RazorSlices;
 
@@ -37,7 +38,10 @@ public abstract class RazorLayoutSlice : RazorSlice, IRazorLayoutSlice
 
         if (ContentSlice is not null)
         {
+            Debug.WriteLine($"Rendering section '{sectionName}' on child slice of type '{ContentSlice.GetType().Name}' from layout slice of type '{GetType().Name}'");
+
             var renderTask = ContentSlice.ExecuteSectionAsync(sectionName);
+
             if (!renderTask.HandleSynchronousCompletion())
             {
                 return AwaitRenderTask(renderTask);

--- a/src/RazorSlices/RazorLayoutSliceOfTModel.cs
+++ b/src/RazorSlices/RazorLayoutSliceOfTModel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Html;
+﻿using System.Diagnostics;
+using Microsoft.AspNetCore.Html;
 
 namespace RazorSlices;
 
@@ -41,7 +42,10 @@ public abstract class RazorLayoutSlice<TModel> : RazorSlice<TModel>, IRazorLayou
 
         if (ContentSlice is not null)
         {
+            Debug.WriteLine($"Rendering section '{sectionName}' on child slice of type '{ContentSlice.GetType().Name}' from layout slice of type '{GetType().Name}'");
+
             var renderTask = ContentSlice.ExecuteSectionAsync(sectionName);
+
             if (!renderTask.HandleSynchronousCompletion())
             {
                 return AwaitRenderTask(renderTask);


### PR DESCRIPTION
The slice was not being initialized before dispatching to the layout to render, so when the layout called into the `ExecuteSectionAsync` method on the slice the injectable properties weren't set yet. Fixed by ensuring that the slice is initialized before dispatching to layout for rendering. Updated the injectable properties sample page to make it rely on the injected service from its override of `ExecuteSectionAsync` so the sample covers this scenario.

Fixes #72