### PR TITLE
Add support for configuring which .cshtml files are Razor Slices

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.0" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@
     app.MapGet("/hello", () => Results.Extensions.RazorSlice<MyApp.Slices.Hello, DateTime>(DateTime.Now));
     ```
 
+1. **Optional:** By default, all *.cshtml* files in your project are treated as Razor Slices. You can change this by setting the `GenerateRazorSlice` metadata to `false` for `RazorSliceGenerate` items in your project file, e.g.:
+
+    ``` xml
+    <ItemGroup>
+        <!-- Don't treat .cshtml files in Views or Pages directory as Razor Slices -->
+        <RazorSliceGenerate Include="Views\**\*.cshtml;Pages\**\*.cshtml" GenerateRazorSlice="false" />
+    </ItemGroup>
+    ```
+
+    This will prevent the Razor Slices source generator from generating proxy types for *.cshtml* files in the *Views* and *Pages* directories in your project.
+
 ## Installation
 
 ### NuGet Releases

--- a/samples/RazorSlices.Samples.RazorClassLibrary/RazorSlices.Samples.RazorClassLibrary.csproj
+++ b/samples/RazorSlices.Samples.RazorClassLibrary/RazorSlices.Samples.RazorClassLibrary.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
+  <!-- Reference the props that would be brought in when consuming the RazorSlices package -->
+  <Import Project="..\..\src\RazorSlices\build\RazorSlices.props" />
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -17,8 +20,7 @@
     <ProjectReference Include="..\..\src\RazorSlices\RazorSlices.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="Slices\FromLibrary.cshtml"></AdditionalFiles>
-  </ItemGroup>
+  <!-- Reference the targets that would be brought in when consuming the RazorSlices package -->
+  <Import Project="..\..\src\RazorSlices\build\RazorSlices.targets" />
 
 </Project>

--- a/samples/RazorSlices.Samples.WebApp/Program.cs
+++ b/samples/RazorSlices.Samples.WebApp/Program.cs
@@ -8,7 +8,14 @@ using Slices = RazorSlices.Samples.WebApp.Slices;
 using LibrarySlices = RazorSlices.Samples.RazorClassLibrary.Slices;
 using Microsoft.AspNetCore.Http.HttpResults;
 
+#if DEBUG
+// Use the default builder during inner-loop so Hot Reload works
 var builder = WebApplication.CreateBuilder(args);
+#else
+// Use the slim builder for Release builds
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.WebHost.UseKestrelHttpsConfiguration();
+#endif
 
 builder.Services.AddWebEncoders();
 builder.Services.AddSingleton<LoremService>();

--- a/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
+++ b/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
@@ -8,6 +8,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!-- BUG: Workaround for https://github.com/dotnet/runtime/issues/109958 -->
+    <NoWarn>IL3000</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
+++ b/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
@@ -23,8 +23,6 @@
     <ProjectReference Include="..\..\src\RazorSlices\RazorSlices.csproj" />
     <ProjectReference Include="..\RazorSlices.Samples.RazorClassLibrary\RazorSlices.Samples.RazorClassLibrary.csproj" />
     <ProjectReference Include="..\..\src\RazorSlices.SourceGenerator\RazorSlices.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-
-    <!-- Don't treat .cshtml files in Views or Pages directory as Razor Slices -->
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
+++ b/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
@@ -17,9 +17,15 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="GenerateRazorSlice" />
+    <CompilerVisibleItemMetadata Include="RazorSliceGenerate" MetadataName="GenerateRazorSlice" />
+
     <ProjectReference Include="..\..\src\RazorSlices\RazorSlices.csproj" />
     <ProjectReference Include="..\RazorSlices.Samples.RazorClassLibrary\RazorSlices.Samples.RazorClassLibrary.csproj" />
     <ProjectReference Include="..\..\src\RazorSlices.SourceGenerator\RazorSlices.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+
+    <RazorSliceGenerate Include="**\*.cshtml" GenerateRazorSlice="true" />
+    <AdditionalFiles Include="@(RazorSliceGenerate)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
+++ b/samples/RazorSlices.Samples.WebApp/RazorSlices.Samples.WebApp.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+ 
+   <!-- Reference the props that would be brought in when consuming the RazorSlices package -->
+   <Import Project="..\..\src\RazorSlices\build\RazorSlices.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
@@ -17,19 +20,18 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="GenerateRazorSlice" />
-    <CompilerVisibleItemMetadata Include="RazorSliceGenerate" MetadataName="GenerateRazorSlice" />
-
     <ProjectReference Include="..\..\src\RazorSlices\RazorSlices.csproj" />
     <ProjectReference Include="..\RazorSlices.Samples.RazorClassLibrary\RazorSlices.Samples.RazorClassLibrary.csproj" />
     <ProjectReference Include="..\..\src\RazorSlices.SourceGenerator\RazorSlices.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 
-    <RazorSliceGenerate Include="**\*.cshtml" GenerateRazorSlice="true" />
-    <AdditionalFiles Include="@(RazorSliceGenerate)" />
+    <!-- Don't treat .cshtml files in Views or Pages directory as Razor Slices -->
   </ItemGroup>
 
   <ItemGroup>
-      <Content Update="package*.json" CopyToPublishDirectory="Never" />
+    <Content Update="package*.json" CopyToPublishDirectory="Never" />
   </ItemGroup>
+
+  <!-- Reference the targets that would be brought in when consuming the RazorSlices package -->
+  <Import Project="..\..\src\RazorSlices\build\RazorSlices.targets" />
 
 </Project>

--- a/src/RazorSlices.SourceGenerator/RazorSliceProxyGenerator.cs
+++ b/src/RazorSlices.SourceGenerator/RazorSliceProxyGenerator.cs
@@ -27,14 +27,13 @@ internal class RazorSliceProxyGenerator : IIncrementalGenerator
         var projectInfo = assemblyName.Combine(rootNamespace.Combine(projectDirectory));
 
         var texts = context.AdditionalTextsProvider
-            .Where(text => text.Path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
-                           && !text.Path.EndsWith("_ViewImports.cshtml", StringComparison.OrdinalIgnoreCase)
-                           && !text.Path.EndsWith("_ViewStart.cshtml", StringComparison.OrdinalIgnoreCase))
+            .Where(text => text.Path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
             .Combine(context.AnalyzerConfigOptionsProvider)
             .Select((pair, _) =>
             {
                 var (additionalText, optionsProvider) = pair;
-                var generateSlice = optionsProvider.GetOptions(additionalText).TryGetValue("build_metadata.AdditionalFiles.GenerateRazorSlice", out var generateRazorSliceValue)
+                var textOptions = optionsProvider.GetOptions(additionalText);
+                var generateSlice = textOptions.TryGetValue("build_metadata.RazorSliceGenerate.GenerateRazorSlice", out var generateRazorSliceValue)
                         && bool.TryParse(generateRazorSliceValue, out var result) && result;
 
                 return (additionalText, generateSlice);

--- a/src/RazorSlices.SourceGenerator/RazorSliceProxyGenerator.cs
+++ b/src/RazorSlices.SourceGenerator/RazorSliceProxyGenerator.cs
@@ -29,7 +29,18 @@ internal class RazorSliceProxyGenerator : IIncrementalGenerator
         var texts = context.AdditionalTextsProvider
             .Where(text => text.Path.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
                            && !text.Path.EndsWith("_ViewImports.cshtml", StringComparison.OrdinalIgnoreCase)
-                           && !text.Path.EndsWith("_ViewStart.cshtml", StringComparison.OrdinalIgnoreCase));
+                           && !text.Path.EndsWith("_ViewStart.cshtml", StringComparison.OrdinalIgnoreCase))
+            .Combine(context.AnalyzerConfigOptionsProvider)
+            .Select((pair, _) =>
+            {
+                var (additionalText, optionsProvider) = pair;
+                var generateSlice = optionsProvider.GetOptions(additionalText).TryGetValue("build_metadata.AdditionalFiles.GenerateRazorSlice", out var generateRazorSliceValue)
+                        && bool.TryParse(generateRazorSliceValue, out var result) && result;
+
+                return (additionalText, generateSlice);
+            })
+            .Where(file => file.generateSlice)
+            .Select((file, _) => file.additionalText);
 
         // (() projectInfo, texts)
         var combined = projectInfo.Combine(texts.Collect());

--- a/src/RazorSlices.SourceGenerator/RazorSlicesGenerator.props
+++ b/src/RazorSlices.SourceGenerator/RazorSlicesGenerator.props
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="GenerateRazorSlice" />
-    <CompilerVisibleItemMetadata Include="RazorSliceGenerate" MetadataName="GenerateRazorSlice" />
-  </ItemGroup>
-</Project>

--- a/src/RazorSlices.SourceGenerator/RazorSlicesGenerator.props
+++ b/src/RazorSlices.SourceGenerator/RazorSlicesGenerator.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="GenerateRazorSlice" />
+    <CompilerVisibleItemMetadata Include="RazorSliceGenerate" MetadataName="GenerateRazorSlice" />
+  </ItemGroup>
+</Project>

--- a/src/RazorSlices/HotReloadService.cs
+++ b/src/RazorSlices/HotReloadService.cs
@@ -14,6 +14,8 @@ namespace RazorSlices;
 /// </summary>
 internal sealed class HotReloadService
 {
+    public static readonly bool IsSupported = bool.TryParse(AppContext.GetData("System.StartupHookProvider.IsSupported")?.ToString() ?? "false", out var value) && value;
+
     public static event Action<Type[]?>? ClearCacheEvent;
     public static event Action<Type[]?>? UpdateApplicationEvent;
 

--- a/src/RazorSlices/RazorSlices.csproj
+++ b/src/RazorSlices/RazorSlices.csproj
@@ -25,18 +25,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include=".\build\**\*.*" Pack="true" PackagePath="build" />
     <None Include="..\..\.editorconfig" Link=".editorconfig" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <InternalsVisibleTo Include="RazorSlices.Tests" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Reference the source generator just to ensure it's built but don't reference its output -->
-    <ProjectReference Include="..\RazorSlices.SourceGenerator\RazorSlices.SourceGenerator.csproj" OutputItemType="None" ReferenceOutputAssembly="false" Private="true" />
-    <!-- Include source generator assembly in this project's package output -->
-    <None Include="@(ProjectReference->'%(RootDir)%(Directory)\bin\$(Configuration)\netstandard2.0\%(Filename).dll')" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,5 +47,17 @@
       <LastGenOutput>RazorSlice.Formattables.cs</LastGenOutput>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference the source generator just to ensure it's built but don't reference its output -->
+    <ProjectReference Include="..\RazorSlices.SourceGenerator\RazorSlices.SourceGenerator.csproj" OutputItemType="SourceGeneratorAssemblyPath" ReferenceOutputAssembly="false" Private="true" />
+  </ItemGroup>
+
+  <!-- Include source generator assembly in this project's package output -->
+  <Target Name="IncludeSourceGeneratorInPackage" AfterTargets="ResolveProjectReferences">
+      <ItemGroup>
+        <None Include="@(SourceGeneratorAssemblyPath -> '%(Identity)')" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+      </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/RazorSlices/SliceDefinition.cs
+++ b/src/RazorSlices/SliceDefinition.cs
@@ -12,6 +12,7 @@ namespace RazorSlices;
 /// </remarks>
 public class SliceDefinition
 {
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     private readonly Type _originalSliceType;
 
     /// <summary>
@@ -25,7 +26,10 @@ public class SliceDefinition
     {
         ArgumentNullException.ThrowIfNull(sliceType);
 
-        HotReloadService.ClearCacheEvent += ReplaceSliceType;
+        if (HotReloadService.IsSupported)
+        {
+            HotReloadService.ClearCacheEvent += ReplaceSliceType;
+        }
 
         _originalSliceType = sliceType;
         Initialize(sliceType);
@@ -45,6 +49,9 @@ public class SliceDefinition
         Factory = RazorSliceFactory.GetSliceFactory(this);
     }
 
+    [UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2067",
+        Justification = "This method should only be called when a type is updated by the Hot Reload service and thus is fine for it to be" +
+                        "trimmed during publish as Hot Reload doesn't run after publish anyway.")]
     private void ReplaceSliceType(Type[]? changedTypes)
     {
         var started = Stopwatch.GetTimestamp();

--- a/src/RazorSlices/build/RazorSlices.props
+++ b/src/RazorSlices/build/RazorSlices.props
@@ -1,0 +1,3 @@
+<Project>
+  
+</Project>

--- a/src/RazorSlices/build/RazorSlices.targets
+++ b/src/RazorSlices/build/RazorSlices.targets
@@ -1,0 +1,12 @@
+<Project>
+  <ItemGroup>
+    <!-- By default, include all *.cshtml files in the project for Razor Slice generation, except those already added by the project & _ViewImports.cshtml, _ViewStart.cshtml -->
+    <RazorSliceGenerate Include="**\*.cshtml" Exclude="@(RazorSliceGenerate);**\_ViewImports.cshtml;**\_ViewStart.cshtml" GenerateRazorSlice="true" />
+
+    <!-- Make the RazorSliceGenerate items visible to the source generator via AdditionalFiles -->
+    <AdditionalFiles Include="@(RazorSliceGenerate)" />
+
+    <!-- Make the RazorSliceGenerate item type and GenerateRazorSlice item metadata visible to the source generator -->
+    <CompilerVisibleItemMetadata Include="RazorSliceGenerate" MetadataName="GenerateRazorSlice" />
+  </ItemGroup>
+</Project>

--- a/tests/BenchmarksWebApps/RazorSlices.Benchmarks.RazorClassLibrary.Local/RazorSlices.Benchmarks.RazorClassLibrary.Local.csproj
+++ b/tests/BenchmarksWebApps/RazorSlices.Benchmarks.RazorClassLibrary.Local/RazorSlices.Benchmarks.RazorClassLibrary.Local.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
+  <!-- Reference the props that would be brought in when consuming the RazorSlices package -->
+  <Import Project="..\..\..\src\RazorSlices\build\RazorSlices.props" />
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -16,5 +19,8 @@
     <ProjectReference Include="..\..\..\src\RazorSlices\RazorSlices.csproj" />
     <ProjectReference Include="..\..\..\src\RazorSlices.SourceGenerator\RazorSlices.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <!-- Reference the targets that would be brought in when consuming the RazorSlices package -->
+  <Import Project="..\..\..\src\RazorSlices\build\RazorSlices.targets" />
 
 </Project>

--- a/tests/BenchmarksWebApps/RazorSlices.Benchmarks.WebApp.RazorSlicesLocal/RazorSlices.Benchmarks.WebApp.RazorSlicesLocal.csproj
+++ b/tests/BenchmarksWebApps/RazorSlices.Benchmarks.WebApp.RazorSlicesLocal/RazorSlices.Benchmarks.WebApp.RazorSlicesLocal.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <!-- Reference the props that would be brought in when consuming the RazorSlices package -->
+  <Import Project="..\..\..\src\RazorSlices\build\RazorSlices.props" />
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -10,5 +13,8 @@
     <ProjectReference Include="..\..\..\src\RazorSlices\RazorSlices.csproj" />
     <ProjectReference Include="..\..\..\src\RazorSlices.SourceGenerator\RazorSlices.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <!-- Reference the targets that would be brought in when consuming the RazorSlices package -->
+  <Import Project="..\..\..\src\RazorSlices\build\RazorSlices.targets" />
 
 </Project>

--- a/tests/RazorSlices.Samples.WebApp.PublishTests/DotNetCli.cs
+++ b/tests/RazorSlices.Samples.WebApp.PublishTests/DotNetCli.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Xunit.Abstractions;
 
 namespace RazorSlices.Samples.WebApp.PublishTests;
 
@@ -13,12 +14,12 @@ public class DotNetCli
         return RunCommand("clean", args);
     }
 
-    public static string Publish(IEnumerable<string> args)
+    public static string Publish(IEnumerable<string> args, ITestOutputHelper? testOutput =  null)
     {
-        return RunCommand("publish", args);
+        return RunCommand("publish", args, testOutput);
     }
 
-    private static string RunCommand(string commandName, IEnumerable<string> args)
+    private static string RunCommand(string commandName, IEnumerable<string> args, ITestOutputHelper? testOutput = null)
     {
         var process = new Process
         {
@@ -38,9 +39,9 @@ public class DotNetCli
         }
 
         var cmdLine = $"{process.StartInfo.FileName} {string.Join(' ', process.StartInfo.ArgumentList)}";
-        Console.WriteLine("Running dotnet CLI with cmd line:");
-        Console.WriteLine(cmdLine);
-        Console.WriteLine();
+        testOutput?.WriteLine("Running dotnet CLI with cmd line:");
+        testOutput?.WriteLine(cmdLine);
+        testOutput?.WriteLine("");
 
         if (!process.Start())
         {

--- a/tests/RazorSlices.Samples.WebApp.PublishTests/PublishSample.cs
+++ b/tests/RazorSlices.Samples.WebApp.PublishTests/PublishSample.cs
@@ -1,8 +1,8 @@
-using System.Diagnostics;
+using Xunit.Abstractions;
 
 namespace RazorSlices.Samples.WebApp.PublishTests;
 
-public class PublishSample
+public class PublishSample(ITestOutputHelper testOutput)
 {
     const string ProjectName = "RazorSlices.Samples.WebApp";
 
@@ -10,10 +10,11 @@ public class PublishSample
     [InlineData(PublishScenario.Default, "net8.0")]
     [InlineData(PublishScenario.Default, "net9.0")]
     //[InlineData(PublishScenario.Trimmed)]
-    //[InlineData(PublishScenario.AOT)]
+    //[InlineData(PublishScenario.AOT, "net8.0")]
+    //[InlineData(PublishScenario.AOT, "net9.0")]
     public void Publish(PublishScenario publishScenario, string tfm)
     {
-        var projectBuilder = new ProjectBuilder(ProjectName, publishScenario);
+        var projectBuilder = new ProjectBuilder(ProjectName, publishScenario, testOutput);
         projectBuilder.Publish(tfm);
 
         Assert.DoesNotContain("warning", projectBuilder.PublishResult?.Output, StringComparison.OrdinalIgnoreCase);

--- a/tests/RazorSlices.Samples.WebApp.PublishTests/RazorSlices.Samples.WebApp.PublishTests.csproj
+++ b/tests/RazorSlices.Samples.WebApp.PublishTests/RazorSlices.Samples.WebApp.PublishTests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="MartinCostello.Logging.XUnit" />
     <Using Include="Xunit"/>
   </ItemGroup>
 


### PR DESCRIPTION
Adds support for configuring which .cshtml files are treated as Razor Slices by the RazorSlices source generator. By default, all .cshtml files are considered Razor Slices (except *_ViewImports.cshtml*  and *_ViewStart.cshtml*). You can change this using the `RazorSliceGenerate` item type in the project file, setting `GenerateRazorSlice` to `true` or `false` accordingly, e.g.:

```xml
<ItemGroup>
  <!-- Don't treat .cshtml files in Views or Pages directory as Razor Slices -->
  <RazorSliceGenerate Include="Views\**\*.cshtml;Pages\**\*.cshtml" GenerateRazorSlice="false" />
</ItemGroup>
```

Also fixes linker warnings that appeared after adding Hot Reload support and updates the publish tests to at least catch those in the future assuming the sample is configured with `<PublishAot>true</PublishAot>`

Fixes #63 