### PR TITLE
Tweak MSBuild targets & generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,19 @@
     app.MapGet("/hello", () => Results.Extensions.RazorSlice<MyApp.Slices.Hello, DateTime>(DateTime.Now));
     ```
 
-1. **Optional:** By default, all *.cshtml* files in your project are treated as Razor Slices. You can change this by setting the `GenerateRazorSlice` metadata to `false` for `RazorSliceGenerate` items in your project file, e.g.:
+1. **Optional:** By default, all *.cshtml* files in your project are treated as Razor Slices (excluding *_ViewImports.cshtml* and *_ViewStart.cshtml_*). You can change this by setting the `EnableDefaultRazorSlices` property to `false` and the `GenerateRazorSlice` metadata property of the desired `RazorGenerate` items to `true` in your project file, e.g.:
 
     ``` xml
+    <PropertyGroup>
+      <EnableDefaultRazorSlices>false</EnableDefaultRazorSlices>
+    </PropertyGroup>
     <ItemGroup>
-        <!-- Don't treat .cshtml files in Views or Pages directory as Razor Slices -->
-        <RazorSliceGenerate Include="Views\**\*.cshtml;Pages\**\*.cshtml" GenerateRazorSlice="false" />
+      <!-- Only treat .cshtml files in Slices directory as Razor Slices -->
+      <RazorGenerate Include="Slices\**\*.cshtml" GenerateRazorSlice="true" />
     </ItemGroup>
     ```
 
-    This will prevent the Razor Slices source generator from generating proxy types for *.cshtml* files in the *Views* and *Pages* directories in your project.
+    This will configure the Razor Slices source generator to only generate proxy types for *.cshtml* files in the *Slices* directory in your project.
 
 ## Installation
 
@@ -213,6 +216,12 @@ The library is still new and features are being actively added.
 - Rendering directly to `PipeWriter`, `Stream`, `TextWriter`, `StringBuilder`, and `string` outputs, including optimizations for not boxing struct values, zero-allocation rendering of primitives like numbers, etc. (rather than just calling `ToString()` on everything)
 - Return a slice instance directly as an `IResult` in minimal APIs via `@inherits RazorSliceHttpResult` and `Results.Extensions.RazorSlice("/Slices/Hello.cshtml")`
 - Full support for trimming and native AOT when used in conjunction with ASP.NET Core Minimal APIs
+- Generated Razor Slice proxy types are `public sealed` by default. To unseal them and make them `public partial` for your own customization, set the `RazorSliceProxiesSealed` property to `false` in your project file, e.g.:
+    ``` xml
+    <PropertyGroup>
+      <RazorSliceProxiesSealed>false</RazorSliceProxiesSealed>
+    </PropertyGroup>
+    ```
 
 ### Interested in supporting but not sure yet
 

--- a/samples/RazorSlices.Samples.RazorClassLibrary/RazorSlices.Samples.RazorClassLibrary.csproj
+++ b/samples/RazorSlices.Samples.RazorClassLibrary/RazorSlices.Samples.RazorClassLibrary.csproj
@@ -9,6 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <RazorSliceProxiesSealed>false</RazorSliceProxiesSealed>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/RazorSlices.Samples.RazorClassLibrary/Slices/FromLibrary.cshtml.cs
+++ b/samples/RazorSlices.Samples.RazorClassLibrary/Slices/FromLibrary.cshtml.cs
@@ -1,0 +1,14 @@
+﻿namespace RazorSlices.Samples.RazorClassLibrary.Slices;
+
+public partial class FromLibrary
+{
+    public class Model
+    {
+        public required string Message { get; init; }
+    }
+
+    public static async Task<string> ExampleCustomRenderAsync(Model model)
+    {
+        return await Create(model).RenderAsync();
+    }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.2</VersionPrefix>
+    <VersionPrefix>0.9.3</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/RazorSlices/build/RazorSlices.props
+++ b/src/RazorSlices/build/RazorSlices.props
@@ -1,3 +1,8 @@
 <Project>
-  
+
+  <PropertyGroup>
+    <EnableDefaultRazorSlices Condition=" '$(EnableDefaultRazorSlices)' == '' ">true</EnableDefaultRazorSlices>
+    <RazorSliceProxiesSealed Condition=" '$(RazorSliceProxiesSealed)' == '' ">true</RazorSliceProxiesSealed>
+  </PropertyGroup>
+
 </Project>

--- a/src/RazorSlices/build/RazorSlices.targets
+++ b/src/RazorSlices/build/RazorSlices.targets
@@ -1,12 +1,24 @@
 <Project>
-  <ItemGroup>
-    <!-- By default, include all *.cshtml files in the project for Razor Slice generation, except those already added by the project & _ViewImports.cshtml, _ViewStart.cshtml -->
-    <RazorSliceGenerate Include="**\*.cshtml" Exclude="@(RazorSliceGenerate);**\_ViewImports.cshtml;**\_ViewStart.cshtml" GenerateRazorSlice="true" />
+  <Target Name="_CheckRazorSlicesDeps" AfterTargets="CollectPackageReferences">
+    <Error Text="Razor Slices requires Razor support for MVC to be enabled. Ensure the project is using the Microsoft.NET.Sdk.Web or Microsoft.NET.Sdk.Razor SDK and that the AddRazorSupportForMvc property is set to 'true'."
+           Condition=" '$(AddRazorSupportForMvc)' != 'true' " />
+  </Target>
+  
+  <Target Name="ResolveRazorSlicesInputs" AfterTargets="ResolveRazorGenerateInputs" DependsOnTargets="_CheckRazorSlicesDeps">
+    <ItemGroup>
+      <!-- By default, include all *.cshtml files in the project for Razor Slice generation, except those already added by the project & _ViewImports.cshtml, _ViewStart.cshtml -->
+      <RazorGenerate Update="@(RazorGenerate)"
+                     GenerateRazorSlice="true"
+                     Condition=" '$(EnableDefaultRazorSlices)' == 'true' AND
+                                 '%(Filename)' != '_ViewImports' AND
+                                 '%(Filename)' != '_ViewStart' " />
 
-    <!-- Make the RazorSliceGenerate items visible to the source generator via AdditionalFiles -->
-    <AdditionalFiles Include="@(RazorSliceGenerate)" />
+      <!-- Make the RazorGenerate items visible to the source generator via AdditionalFiles -->
+      <AdditionalFiles Include="@(RazorGenerate)" />
 
-    <!-- Make the RazorSliceGenerate item type and GenerateRazorSlice item metadata visible to the source generator -->
-    <CompilerVisibleItemMetadata Include="RazorSliceGenerate" MetadataName="GenerateRazorSlice" />
-  </ItemGroup>
+      <!-- Make the RazorGenerate item type and GenerateRazorSlice item metadata visible to the source generator -->
+      <CompilerVisibleItemMetadata Include="RazorGenerate" MetadataName="GenerateRazorSlice" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
Some tweaks to the targets and source generator that hopefully resolves issues caused by the custom item type (it's gone now) and enables making the generated types `public partial` instead of `public sealed`. Also emits a build error when required SDK isn't being used or configured correctly.

Fixes #94
Fixes #66
Related to #85 (might fix it but won't be totally sure until users report that the issue is gone for them)
Possibly will help #93 too (if it's caused by the custom item type)