### PR TITLE
Fix dotnet-watch duplicate source file warnings

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.3</VersionPrefix>
+    <VersionPrefix>0.9.4</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/RazorSlices/build/RazorSlices.targets
+++ b/src/RazorSlices/build/RazorSlices.targets
@@ -13,9 +13,6 @@
                                  '%(Filename)' != '_ViewImports' AND
                                  '%(Filename)' != '_ViewStart' " />
 
-      <!-- Make the RazorGenerate items visible to the source generator via AdditionalFiles -->
-      <AdditionalFiles Include="@(RazorGenerate)" />
-
       <!-- Make the RazorGenerate item type and GenerateRazorSlice item metadata visible to the source generator -->
       <CompilerVisibleItemMetadata Include="RazorGenerate" MetadataName="GenerateRazorSlice" />
     </ItemGroup>


### PR DESCRIPTION
Bump version prefix to 0.9.4 and remove `AdditionalFiles` inclusion for `RazorGenerate` items from targets.

Fixes #93

<img width="1459" height="435" alt="image" src="https://github.com/user-attachments/assets/13edca77-fe3b-48fd-b698-d51b355ddfac" />
