### PR TITLE
Fix source generator missing from NuGet package after multi-targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     @using System.Globalization;
     @using Microsoft.AspNetCore.Razor;
     @using Microsoft.AspNetCore.Http.HttpResults;
+    @using RazorSlices;
     
     @tagHelperPrefix __disable_tagHelpers__:
     @removeTagHelper *, Microsoft.AspNetCore.Mvc.Razor
@@ -57,7 +58,7 @@
 1. Add a minimal API to return the slice in your *Program.cs*:
 
     ``` csharp
-    app.MapGet("/hello", () => Results.Extensions.RazorSlice<MyApp.Slices.Hello, DateTime>(DateTime.Now));
+    app.MapGet("/hello", () => MyApp.Slices.Hello.Create(DateTime.Now));
     ```
 
 1. **Optional:** By default, all *.cshtml* files in your project are treated as Razor Slices (excluding *_ViewImports.cshtml* and *_ViewStart.cshtml_*). You can change this by setting the `EnableDefaultRazorSlices` property to `false` and then including the desired `RazorSlice` items in your project file, e.g.:

--- a/src/RazorSlices/RazorSlices.csproj
+++ b/src/RazorSlices/RazorSlices.csproj
@@ -53,11 +53,15 @@
     <ProjectReference Include="..\SourceGenerator\SourceGenerator.csproj" OutputItemType="SourceGeneratorAssemblyPath" ReferenceOutputAssembly="false" Private="true" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeSourceGeneratorInPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
   <!-- Include source generator assembly in this project's package output -->
-  <Target Name="IncludeSourceGeneratorInPackage" AfterTargets="ResolveProjectReferences">
-      <ItemGroup>
-        <None Include="@(SourceGeneratorAssemblyPath -> '%(Identity)')" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-      </ItemGroup>
+  <Target Name="IncludeSourceGeneratorInPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(SourceGeneratorAssemblyPath)" PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/tests/Samples.WebApp.PublishTests/DotNetCli.cs
+++ b/tests/Samples.WebApp.PublishTests/DotNetCli.cs
@@ -19,6 +19,18 @@ public class DotNetCli
         return RunCommand("publish", args, testOutput);
     }
 
+    public static string Pack(string projectPath, string outputDir, ITestOutputHelper? testOutput = null)
+    {
+        var args = new List<string>
+        {
+            projectPath,
+            "--configuration", "Release",
+            "--output", outputDir,
+            "--no-restore"
+        };
+        return RunCommand("pack", args, testOutput);
+    }
+
     private static string RunCommand(string commandName, IEnumerable<string> args, ITestOutputHelper? testOutput = null)
     {
         var process = new Process

--- a/tests/Samples.WebApp.PublishTests/PackageContentsTests.cs
+++ b/tests/Samples.WebApp.PublishTests/PackageContentsTests.cs
@@ -1,0 +1,43 @@
+using System.IO.Compression;
+using Xunit.Abstractions;
+
+namespace RazorSlices.Samples.WebApp.PublishTests;
+
+public class PackageContentsTests(ITestOutputHelper testOutput)
+{
+    [Fact]
+    public void Package_ContainsExpectedAssets()
+    {
+        var projectPath = Path.Combine(PathHelper.RepoRoot, "src", "RazorSlices", "RazorSlices.csproj");
+        var outputDir = Path.Combine(PathHelper.ArtifactsDir, "TestOutput", Path.GetRandomFileName(), "pack");
+        Directory.CreateDirectory(outputDir);
+
+        var packOutput = DotNetCli.Pack(projectPath, outputDir, testOutput);
+        testOutput.WriteLine(packOutput);
+
+        var nupkgFiles = Directory.GetFiles(outputDir, "*.nupkg");
+        Assert.Single(nupkgFiles);
+
+        var nupkgPath = nupkgFiles[0];
+        testOutput.WriteLine($"Inspecting package: {nupkgPath}");
+
+        using var archive = ZipFile.OpenRead(nupkgPath);
+        var entries = archive.Entries.Select(e => e.FullName.Replace('\\', '/')).ToList();
+
+        foreach (var entry in entries.OrderBy(e => e))
+        {
+            testOutput.WriteLine($"  {entry}");
+        }
+
+        // Source generator must be present
+        Assert.Contains(entries, e => e.Equals("analyzers/dotnet/cs/RazorSlices.SourceGenerator.dll", StringComparison.OrdinalIgnoreCase));
+
+        // Build props and targets must be present
+        Assert.Contains(entries, e => e.Equals("build/RazorSlices.props", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(entries, e => e.Equals("build/RazorSlices.targets", StringComparison.OrdinalIgnoreCase));
+
+        // Library assemblies for each targeted framework must be present
+        Assert.Contains(entries, e => e.Equals("lib/net8.0/RazorSlices.dll", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(entries, e => e.Equals("lib/net10.0/RazorSlices.dll", StringComparison.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #107 — The source generator DLL was silently dropped from the NuGet package when the library switched from single-targeting (\
et8.0\) to multi-targeting (\
et8.0;net10.0\).

## Root Cause

The \IncludeSourceGeneratorInPackage\ MSBuild target runs \AfterTargets="ResolveProjectReferences"\, but with multi-targeting, \dotnet pack\ runs an outer build that dispatches to inner builds per TFM. The \@(SourceGeneratorAssemblyPath)\ item is empty in the outer build context, so \nalyzers/dotnet/cs/RazorSlices.SourceGenerator.dll\ was silently omitted from the package.

## Changes

### Fix: Source generator packaging (\src/RazorSlices/RazorSlices.csproj\)
- Replaced the broken target with one using \TargetsForTfmSpecificContentInPackage\ + \TfmSpecificPackageFile\ items
- Conditioned on \
et8.0\ TFM to avoid duplicate file errors (source generator is the same for all TFMs)

### Fix: README documentation (\README.md\)
- Added missing \@using RazorSlices\ to the \_ViewImports.cshtml\ example (required for \RazorSlice\ type resolution)
- Updated \Program.cs\ example from obsolete \Results.Extensions.RazorSlice<>()\ to the recommended \Create()\ API

### Regression prevention (\	ests/Samples.WebApp.PublishTests/\)
- Added \PackageContentsTests\ that packs the library and verifies the \.nupkg\ contains:
  - \nalyzers/dotnet/cs/RazorSlices.SourceGenerator.dll\
  - \uild/RazorSlices.props\ and \uild/RazorSlices.targets\
  - \lib/net8.0/RazorSlices.dll\ and \lib/net10.0/RazorSlices.dll\
- Added \DotNetCli.Pack()\ helper method

## Testing

All 101 tests pass, including the new package contents verification test.