### PR TITLE
Allow overriding RazorSlice content type

### DIFF
--- a/src/RazorSlices/RazorSlice.IResult.cs
+++ b/src/RazorSlices/RazorSlice.IResult.cs
@@ -15,9 +15,9 @@ public abstract partial class RazorSlice : IResult, IStatusCodeHttpResult, ICont
     int? IStatusCodeHttpResult.StatusCode { get => StatusCode; }
 
     /// <summary>
-    /// Gets the content type: <c>text/html; charset=utf-8</c>
+    /// Gets or sets the HTTP response content type. Defaults to <c>text/html; charset=utf-8</c>.
     /// </summary>
-    public string ContentType => "text/html; charset=utf-8";
+    public string ContentType { get; set; } = "text/html; charset=utf-8";
 
     /// <summary>
     /// Gets or sets the <see cref="System.Text.Encodings.Web.HtmlEncoder" /> instance to use when rendering the template. If

--- a/tests/RazorSlices/RazorSliceIResultTests.cs
+++ b/tests/RazorSlices/RazorSliceIResultTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Http;
+
+namespace RazorSlices.Tests;
+
+public class RazorSliceIResultTests
+{
+    [Fact]
+    public async Task ExecuteAsync_UsesDefaultHtmlContentType()
+    {
+        var slice = new TestSlice
+        {
+            HtmlEncoder = HtmlEncoder.Default
+        };
+        var httpContext = CreateHttpContext();
+
+        await ((IResult)slice).ExecuteAsync(httpContext);
+
+        Assert.Equal("text/html; charset=utf-8", httpContext.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UsesOverriddenContentType()
+    {
+        var slice = new TestSlice
+        {
+            ContentType = "application/xml; charset=utf-8",
+            HtmlEncoder = HtmlEncoder.Default
+        };
+        var httpContext = CreateHttpContext();
+
+        await ((IResult)slice).ExecuteAsync(httpContext);
+
+        Assert.Equal("application/xml; charset=utf-8", httpContext.Response.ContentType);
+    }
+
+    private static HttpContext CreateHttpContext()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+        return httpContext;
+    }
+
+    private sealed class TestSlice : RazorSlice
+    {
+        public override Task ExecuteAsync() => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- make RazorSlice.ContentType settable while keeping the current HTML default
- add regression tests for the explicit IResult execution path
- preserve existing behavior unless callers override the content type

Fixes #120