### PR TITLE
Use correct encoding when writing UTF8 bytes to TextWriter

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <VersionPrefix>0.10.0</VersionPrefix>
+    <VersionPrefix>0.10.1</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/RazorSlices/TextWriterHtmlExtensions.cs
+++ b/src/RazorSlices/TextWriterHtmlExtensions.cs
@@ -144,9 +144,9 @@ internal static class TextWriterHtmlExtensions
     {
         var charCount = Encoding.UTF8.GetCharCount(value);
         var buffer = ArrayPool<char>.Shared.Rent(charCount);
-        var bytesDecoded = Encoding.UTF8.GetChars(value, buffer);
+        var charsWritten = Encoding.UTF8.GetChars(value, buffer);
 
-        Debug.Assert(bytesDecoded == value.Length, "Bad decoding when writing to TextWriter in HtmlEncodeAndWriteUtf8(ReadOnlySpan<byte>)");
+        Debug.Assert(charsWritten == charCount, "Bad decoding when writing to TextWriter in HtmlEncodeAndWriteUtf8(ReadOnlySpan<byte>)");
 
         htmlEncoder.Encode(textWriter, buffer, 0, charCount);
         ArrayPool<char>.Shared.Return(buffer);
@@ -154,11 +154,11 @@ internal static class TextWriterHtmlExtensions
 
     public static void WriteUtf8(this TextWriter textWriter, ReadOnlySpan<byte> value)
     {
-        var charCount = Encoding.Unicode.GetCharCount(value);
+        var charCount = Encoding.UTF8.GetCharCount(value);
         var buffer = ArrayPool<char>.Shared.Rent(charCount);
-        var bytesDecoded = Encoding.Unicode.GetChars(value, buffer);
+        var charsWritten = Encoding.UTF8.GetChars(value, buffer);
 
-        Debug.Assert(bytesDecoded == value.Length, "Bad decoding when writing to TextWriter in WriteUtf8(ReadOnlySpan<byte>)");
+        Debug.Assert(charsWritten == charCount, "Bad decoding when writing to TextWriter in WriteUtf8(ReadOnlySpan<byte>)");
 
         textWriter.Write(buffer, 0, charCount);
         ArrayPool<char>.Shared.Return(buffer);

--- a/tests/RazorSlices/TextWriterHtmlExtensionsTests.cs
+++ b/tests/RazorSlices/TextWriterHtmlExtensionsTests.cs
@@ -1,0 +1,128 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace RazorSlices.Tests;
+
+public class TextWriterHtmlExtensionsTests
+{
+    [Fact]
+    public void WriteUtf8_WritesAsciiTextCorrectly()
+    {
+        var writer = new StringWriter();
+        var utf8Bytes = Encoding.UTF8.GetBytes("Hello, World!");
+
+        writer.WriteUtf8(utf8Bytes);
+
+        Assert.Equal("Hello, World!", writer.ToString());
+    }
+
+    [Fact]
+    public void WriteUtf8_WritesMultiByteUtf8TextCorrectly()
+    {
+        var writer = new StringWriter();
+        var text = "Héllo, Wörld! 日本語 🎉";
+        var utf8Bytes = Encoding.UTF8.GetBytes(text);
+
+        writer.WriteUtf8(utf8Bytes);
+
+        Assert.Equal(text, writer.ToString());
+    }
+
+    [Fact]
+    public void WriteUtf8_WritesEmptySpanCorrectly()
+    {
+        var writer = new StringWriter();
+
+        writer.WriteUtf8(ReadOnlySpan<byte>.Empty);
+
+        Assert.Equal("", writer.ToString());
+    }
+
+    [Fact]
+    public void WriteUtf8_WritesHtmlCharsWithoutEncoding()
+    {
+        var writer = new StringWriter();
+        var text = "<div class=\"test\">&amp;</div>";
+        var utf8Bytes = Encoding.UTF8.GetBytes(text);
+
+        writer.WriteUtf8(utf8Bytes);
+
+        Assert.Equal(text, writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteUtf8_EncodesHtmlCharacters()
+    {
+        var writer = new StringWriter();
+        var utf8Bytes = Encoding.UTF8.GetBytes("<script>alert('xss')</script>");
+
+        writer.HtmlEncodeAndWriteUtf8(utf8Bytes, HtmlEncoder.Default);
+
+        Assert.Equal("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;", writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteUtf8_WritesTextThatRequiresNoEncoding()
+    {
+        var writer = new StringWriter();
+        var text = "Hello, World!";
+        var utf8Bytes = Encoding.UTF8.GetBytes(text);
+
+        writer.HtmlEncodeAndWriteUtf8(utf8Bytes, HtmlEncoder.Default);
+
+        Assert.Equal(text, writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteUtf8_DoesNotEncodeWithNullEncoder()
+    {
+        var writer = new StringWriter();
+        var text = "Hello, <World>!";
+        var utf8Bytes = Encoding.UTF8.GetBytes(text);
+
+        writer.HtmlEncodeAndWriteUtf8(utf8Bytes, NullHtmlEncoder.Default);
+
+        Assert.Equal(text, writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteUtf8_HandlesMultiByteUtf8Characters()
+    {
+        var writer = new StringWriter();
+        var text = "Héllo <Wörld> 日本語";
+        var utf8Bytes = Encoding.UTF8.GetBytes(text);
+
+        writer.HtmlEncodeAndWriteUtf8(utf8Bytes, HtmlEncoder.Default);
+
+        var result = writer.ToString();
+        Assert.Contains("&lt;", result);
+        Assert.Contains("&gt;", result);
+        Assert.Contains("H&#xE9;llo", result);
+    }
+
+    [Fact]
+    public void WriteUtf8_WritesLargeUtf8TextCorrectly()
+    {
+        var writer = new StringWriter();
+        var text = new string('a', 10_000) + "日本語" + new string('b', 10_000);
+        var utf8Bytes = Encoding.UTF8.GetBytes(text);
+
+        writer.WriteUtf8(utf8Bytes);
+
+        Assert.Equal(text, writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteUtf8_EncodesLargeUtf8Text()
+    {
+        var writer = new StringWriter();
+        var text = new string('<', 1_000);
+        var utf8Bytes = Encoding.UTF8.GetBytes(text);
+
+        writer.HtmlEncodeAndWriteUtf8(utf8Bytes, HtmlEncoder.Default);
+
+        var expected = string.Concat(Enumerable.Repeat("&lt;", 1_000));
+        Assert.Equal(expected, writer.ToString());
+    }
+}


### PR DESCRIPTION
Fix the bad encoding call

Closes #126