### PR TITLE
Fix WriteHtml string output

### DIFF
--- a/src/RazorSlices/RazorSlice.Write.cs
+++ b/src/RazorSlices/RazorSlice.Write.cs
@@ -402,7 +402,7 @@ public partial class RazorSlice
     /// <returns><see cref="HtmlString.Empty"/> to allow for easy calling via a Razor expression, e.g. <c>@WriteHtml(Model.SomeHtml)</c></returns>
     protected HtmlString WriteHtml(string? htmlString)
     {
-        if (string.IsNullOrEmpty(htmlString))
+        if (!string.IsNullOrEmpty(htmlString))
         {
             _pipeWriter?.WriteHtml(htmlString.AsSpan());
             _textWriter?.Write(htmlString);

--- a/tests/RazorSlices/RazorSliceWriteHtmlTests.cs
+++ b/tests/RazorSlices/RazorSliceWriteHtmlTests.cs
@@ -1,0 +1,62 @@
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Encodings.Web;
+
+namespace RazorSlices.Tests;
+
+public class RazorSliceWriteHtmlTests
+{
+    [Fact]
+    public async Task WriteHtmlString_WritesRawHtmlToTextWriter()
+    {
+        var writer = new StringWriter();
+        var slice = new WriteHtmlStringSlice("<span>&</span>");
+
+        await slice.RenderAsync(writer, HtmlEncoder.Default);
+
+        Assert.Equal("<span>&</span>", writer.ToString());
+    }
+
+    [Fact]
+    public async Task WriteHtmlString_WritesRawHtmlToPipeWriter()
+    {
+        using var stream = new MemoryStream();
+        var pipeWriter = PipeWriter.Create(stream);
+        var slice = new WriteHtmlStringSlice("<span>&</span>");
+
+        await slice.RenderAsync(pipeWriter, HtmlEncoder.Default);
+        await pipeWriter.FlushAsync();
+        await pipeWriter.CompleteAsync();
+
+        Assert.Equal("<span>&</span>", Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task WriteHtmlString_DoesNotWriteNullOrEmptyString(string? html)
+    {
+        var writer = new StringWriter();
+        var slice = new WriteHtmlStringSlice(html);
+
+        await slice.RenderAsync(writer, HtmlEncoder.Default);
+
+        Assert.Equal("", writer.ToString());
+    }
+
+    private sealed class WriteHtmlStringSlice : RazorSlice
+    {
+        private readonly string? _html;
+
+        public WriteHtmlStringSlice(string? html)
+        {
+            _html = html;
+        }
+
+        public override Task ExecuteAsync()
+        {
+            WriteHtml(_html);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #125.

## Summary
- Correct the inverted null-or-empty guard in `WriteHtml(string?)` so non-empty raw HTML strings are written.
- Add regression coverage for both `TextWriter` and `PipeWriter` rendering paths, plus null/empty inputs.

## Validation
- `dotnet test tests\RazorSlices\RazorSlices.Tests.csproj --no-restore`
- `dotnet test`