### PR TITLE
Update GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -22,10 +22,10 @@ jobs:
       DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Install .NET SDKs/runtimes
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: |
           8.0.x
@@ -70,7 +70,7 @@ jobs:
       run: dotnet pack --configuration Release --output ./artifacts/ship --verbosity normal -p:BuildNumber=$BUILD_NUMBER -p:SourceRevisionId=$GITHUB_SHA -p:ContinuousIntegrationBuild=true -p:IsShipCandidate=true
 
     - name: Upload artifacts (packages)
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: nupkg
         path: ./artifacts/**/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: write
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -35,10 +39,10 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
 
       - name: Add GitHub Package Repository source
         run: dotnet nuget add source --username DamianEdwards --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name GPR "https://nuget.pkg.github.com/DamianEdwards/index.json"
@@ -47,8 +51,25 @@ jobs:
         run: dotnet nuget push **/ci/*.nupkg --source "GPR" --skip-duplicate
 
       - name: Delete old packages
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
-        with:
-          min-versions-to-keep: 5
-          package-type: 'nuget'
-          package-name: '${{ env.PACKAGE_ID }}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner="${{ github.repository_owner }}"
+          packageName="${{ env.PACKAGE_ID }}"
+          keep=5
+
+          versionIds=$(
+            gh api --paginate "/users/$owner/packages/nuget/$packageName/versions?per_page=100" \
+              --jq '.[] | { id, created_at }' |
+              jq -rs --argjson keep "$keep" 'sort_by(.created_at) | reverse | .[$keep:][]?.id'
+          )
+
+          if [ -z "$versionIds" ]; then
+            echo "No old package versions to delete."
+            exit 0
+          fi
+
+          for versionId in $versionIds; do
+            echo "Deleting package version $versionId"
+            gh api --method DELETE "/users/$owner/packages/nuget/$packageName/versions/$versionId"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,23 +30,28 @@ jobs:
       DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
 
     steps:
-      - name: Download workflow run details
-        run: |
-          workflowUrl="https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ inputs.runId }}"
-          curl -s -H "Accept: application/json" "${workflowUrl}" > workflow_details.json
-
-      - name: Extract workflow run commit SHA
-        uses: sergeysova/jq-action@a3f0d4ff59cc1dddf023fc0b325dd75b10deec58 # v2
+      - name: Get workflow run commit SHA
         id: workflowsha
-        with:
-          cmd: 'jq .head_sha workflow_details.json -r'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          runDetails=$(gh api "repos/${{ github.repository }}/actions/runs/${{ inputs.runId }}")
+          conclusion=$(echo "$runDetails" | jq -r '.conclusion')
+          if [ "$conclusion" != "success" ]; then
+            echo "Workflow run ${{ inputs.runId }} concluded with '$conclusion', expected 'success'."
+            exit 1
+          fi
+
+          sha=$(echo "$runDetails" | jq -r '.head_sha')
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Download workflow run artifacts
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          run_id: ${{ inputs.runId }}
-          workflow_conclusion: success
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.runId }}
           name: nupkg
+          path: .
       
       - name: Get package version into an environment variable
         run: |
@@ -74,20 +79,22 @@ jobs:
           fi
 
       - name: Create release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
-        with:
-          tag: v${{ env.PACKAGE_VERSION }}
-          commit: ${{ steps.workflowsha.outputs.value }}
-          generateReleaseNotes: true
-          draft: true
-          prerelease: ${{ contains(env.PACKAGE_VERSION, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          args=(--target "${{ steps.workflowsha.outputs.sha }}" --generate-notes --draft)
+          if [[ "$PACKAGE_VERSION" == *-* ]]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "v$PACKAGE_VERSION" "${args[@]}"
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
 
       - name: NuGet login (OIDC)
         id: nuget-login
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary
- update first-party GitHub Actions to pinned Node 24-capable versions
- replace Node 20-dependent package cleanup/release helper actions with `gh api`/shell steps
- switch release artifact download to first-party `actions/download-artifact`

Fixes #129