### PR TITLE
Fix conditional attribute rendering

### DIFF
--- a/samples/WebApp/MapSlices.cs
+++ b/samples/WebApp/MapSlices.cs
@@ -30,6 +30,7 @@ internal static class MapSlicesExtensions
             await slice.RenderAsync(httpResponse.Body);
         });
         endpoints.MapGet("/encoding", () => Results.RazorSlice<Slices.Encoding>());
+        endpoints.MapGet("/attribute-rendering", () => Results.RazorSlice<Slices.AttributeRendering>());
         endpoints.MapGet("/unicode", () => Results.RazorSlice<Slices.Unicode>());
         endpoints.MapGet("/templated", (bool async = false) => Results.RazorSlice<Slices.Templated, bool>(async));
         endpoints.MapGet("/library", () => Results.RazorSlice<LibrarySlices.FromLibrary>());
@@ -77,6 +78,7 @@ internal static class MapSlicesExtensions
             await slice.RenderAsync(httpResponse.Body);
         });
         endpoints.MapGet("/encoding", () => Results.Extensions.RazorSlice<Slices.Encoding>());
+        endpoints.MapGet("/attribute-rendering", () => Results.Extensions.RazorSlice<Slices.AttributeRendering>());
         endpoints.MapGet("/unicode", () => Results.Extensions.RazorSlice<Slices.Unicode>());
         endpoints.MapGet("/templated", (bool async = false) => Results.Extensions.RazorSlice<Slices.Templated, bool>(async));
         endpoints.MapGet("/library", () => Results.Extensions.RazorSlice<LibrarySlices.FromLibrary>());

--- a/samples/WebApp/Slices/AttributeRendering.cshtml
+++ b/samples/WebApp/Slices/AttributeRendering.cshtml
@@ -1,4 +1,7 @@
 @inherits RazorSlice
+@implements IUsesLayout<_Layout, LayoutModel>
+
+<h1 class="mt-5">Attribute rendering</h1>
 
 <div class="@false">False</div>
 <div class="@null">Null</div>
@@ -8,3 +11,7 @@
 <input type="checkbox" checked="@true" name="true" />
 <input type="checkbox" checked="@false" name="false" />
 <input type="checkbox" checked="@null" name="null" />
+
+@functions {
+    public LayoutModel LayoutModel => new() { Title = "Attribute rendering" };
+}

--- a/samples/WebApp/Slices/AttributeRendering.cshtml
+++ b/samples/WebApp/Slices/AttributeRendering.cshtml
@@ -1,0 +1,10 @@
+@inherits RazorSlice
+
+<div class="@false">False</div>
+<div class="@null">Null</div>
+<div class="@("")">Empty</div>
+<div class="@("false")">False String</div>
+<div class="@("active")">String</div>
+<input type="checkbox" checked="@true" name="true" />
+<input type="checkbox" checked="@false" name="false" />
+<input type="checkbox" checked="@null" name="null" />

--- a/samples/WebApp/Slices/_FooterLinks.cshtml
+++ b/samples/WebApp/Slices/_FooterLinks.cshtml
@@ -3,6 +3,7 @@
 <a href="/lorem"><span class="text-muted">Lorem</span></a> |
 <a href="/templated"><span class="text-muted">Templated</span></a> |
 <a href="/encoding"><span class="text-muted">Encoding</span></a> |
+<a href="/attribute-rendering"><span class="text-muted">Attribute rendering</span></a> |
 <a href="/unicode"><span class="text-muted">Unicode</span></a> |
 <a href="/render-to-string"><span class="text-muted">Render to string</span></a> |
 <a href="/render-to-stringbuilder"><span class="text-muted">Render to StringBuilder</span></a> |

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <VersionPrefix>0.11.1</VersionPrefix>
+    <VersionPrefix>0.11.2</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/RazorSlices/RazorSlice.HtmlAttributes.cs
+++ b/src/RazorSlices/RazorSlice.HtmlAttributes.cs
@@ -63,6 +63,30 @@ public abstract partial class RazorSlice
     protected void WriteAttributeValue(
         string prefix,
         int prefixOffset,
+        bool value,
+        int valueOffset,
+        int valueLength,
+        bool isLiteral)
+    {
+        WriteAttributeValue(prefix, prefixOffset, (bool?)value, valueOffset, valueLength, isLiteral);
+    }
+
+    /// <summary>
+    /// Writes out a <see cref="bool"/> attribute value.
+    /// </summary>
+    /// <remarks>
+    /// You generally shouldn't call this method directly. The Razor compiler will emit the appropriate calls to this method for
+    /// all HTML attributes containing Razor expressions in your .cshtml file.
+    /// </remarks>
+    /// <param name="prefix">The prefix.</param>
+    /// <param name="prefixOffset">The prefix offset.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="valueOffset">The value offset.</param>
+    /// <param name="valueLength">The value length.</param>
+    /// <param name="isLiteral">Whether the attribute is a literal.</param>
+    protected void WriteAttributeValue(
+        string prefix,
+        int prefixOffset,
         bool? value,
 #pragma warning disable IDE0060 // Remove unused parameter
         int valueOffset,
@@ -154,12 +178,14 @@ public abstract partial class RazorSlice
 #pragma warning restore IDE0060 // Remove unused parameter
         bool isLiteral)
     {
+        if (value is bool boolValue)
+        {
+            WriteAttributeValue(prefix, prefixOffset, boolValue, valueOffset, valueLength, isLiteral);
+            return;
+        }
+
         if (_attributeInfo.AttributeValuesCount == 1)
         {
-            // NOTE: In some edge cases, 'value' could render an empty string, e.g. custom ISpanFormattable/IHtmlContent, and thus
-            //       this IsNullValue() check will fail, but we want to avoid any allocation here so we only check if the value is
-            //       null or is actually a string and is empty. In the edge case, the attribute will still be rendered with an
-            //       empty value.
             if (IsNullValue(prefix, value))
             {
                 // Value is null with no prefix; don't render the attribute.
@@ -193,9 +219,7 @@ public abstract partial class RazorSlice
 
         static bool IsNullValue(string? prefix, TValue? value)
         {
-            return string.IsNullOrEmpty(prefix)
-                && (value is null
-                    || (value is string && string.IsNullOrEmpty((string)(object)value)));
+            return string.IsNullOrEmpty(prefix) && value is null;
         }
     }
 

--- a/tests/RazorSlices/RazorSliceHtmlAttributesTests.cs
+++ b/tests/RazorSlices/RazorSliceHtmlAttributesTests.cs
@@ -1,0 +1,36 @@
+namespace RazorSlices.Tests;
+
+public class RazorSliceHtmlAttributesTests
+{
+    [Theory]
+    [InlineData(true, " checked=\"checked\"")]
+    [InlineData(false, "")]
+    public async Task ObjectTypedBoolean_RendersConditionalAttribute(bool value, string expected)
+    {
+        var slice = new ObjectAttributeSlice("checked", value);
+
+        Assert.Equal(expected, await slice.RenderAsync());
+    }
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", " class=\"\"")]
+    [InlineData("active", " class=\"active\"")]
+    public async Task ObjectTypedString_RendersConditionalAttribute(string? value, string expected)
+    {
+        var slice = new ObjectAttributeSlice("class", value);
+
+        Assert.Equal(expected, await slice.RenderAsync());
+    }
+
+    private sealed class ObjectAttributeSlice(string name, object? value) : RazorSlice
+    {
+        public override Task ExecuteAsync()
+        {
+            BeginWriteAttribute(name, $" {name}=\"", 0, "\"", 0, 1);
+            WriteAttributeValue("", 0, value, 0, 0, false);
+            EndWriteAttribute();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Samples.WebApp/WebAppTests.cs
+++ b/tests/Samples.WebApp/WebAppTests.cs
@@ -30,7 +30,7 @@ public class WebAppTests
 
         var html = await httpClient.GetStringAsync("/attribute-rendering");
 
-        Assert.Equal(
+        Assert.Contains(
             """
             <div>False</div>
             <div>Null</div>
@@ -41,7 +41,7 @@ public class WebAppTests
             <input type="checkbox" name="false" />
             <input type="checkbox" name="null" />
             """,
-            html.Trim().ReplaceLineEndings());
+            html.ReplaceLineEndings());
     }
 
     public static object[][] EndpointDetails => [

--- a/tests/Samples.WebApp/WebAppTests.cs
+++ b/tests/Samples.WebApp/WebAppTests.cs
@@ -22,6 +22,28 @@ public class WebAppTests
         Assert.Contains(shouldContain, await response.Content.ReadAsStringAsync());
     }
 
+    [Fact]
+    public async Task AttributeRendering_RendersConditionalAttributes()
+    {
+        var waf = new WebApplicationFactory<Program>();
+        using var httpClient = waf.CreateClient();
+
+        var html = await httpClient.GetStringAsync("/attribute-rendering");
+
+        Assert.Equal(
+            """
+            <div>False</div>
+            <div>Null</div>
+            <div class="">Empty</div>
+            <div class="false">False String</div>
+            <div class="active">String</div>
+            <input type="checkbox" checked="checked" name="true" />
+            <input type="checkbox" name="false" />
+            <input type="checkbox" name="null" />
+            """,
+            html.Trim().ReplaceLineEndings());
+    }
+
     public static object[][] EndpointDetails => [
         ["/", "Todos", MediaTypeNames.Text.Html],
         ["/1", "Wash the dishes", MediaTypeNames.Text.Html],


### PR DESCRIPTION
## Summary
- add an exact `bool` attribute overload so Razor-generated boolean expressions use conditional attribute semantics without boxing
- preserve empty-string attributes and handle boxed boolean values in the generic fallback
- add generated Razor and object-typed regression coverage
- bump the package patch version to `0.11.2`

Fixes #133

## Validation
- `dotnet test tests/RazorSlices/RazorSlices.Tests.csproj`
- `dotnet test tests/Samples.WebApp/Samples.WebApp.csproj` (.NET 8, 9, and 10)
- managed Release publish for `samples/WebApp`