### PR TITLE
Write only the encoded chars when writing ISpanFormattable to a TextWriter

### DIFF
--- a/src/RazorSlices/TextWriterHtmlExtensions.cs
+++ b/src/RazorSlices/TextWriterHtmlExtensions.cs
@@ -64,7 +64,7 @@ internal static class TextWriterHtmlExtensions
 
         if (waitingToWrite > 0)
         {
-            textWriter.Write(encodeBufferSpan);
+            textWriter.Write(encodeBuffer.AsSpan()[..waitingToWrite]);
         }
 
         ArrayPool<char>.Shared.Return(encodeBuffer);
@@ -82,8 +82,9 @@ internal static class TextWriterHtmlExtensions
             if ((charsWritten * BufferSizes.HtmlEncodeAllowanceRatio) < BufferSizes.SmallFormattableWriteCharSize)
             {
                 Span<char> encodedBuffer = stackalloc char[BufferSizes.SmallFormattableWriteCharSize];
-                if (htmlEncoder.Encode(formatBuffer, encodedBuffer, out var charsConsumed, out var charsEncoded) == OperationStatus.Done)
+                if (htmlEncoder.Encode(formatBuffer[..charsWritten], encodedBuffer, out var charsConsumed, out var charsEncoded) == OperationStatus.Done)
                 {
+                    textWriter.Write(encodedBuffer[..charsEncoded]);
                     return true;
                 }
             }

--- a/tests/RazorSlices/TextWriterHtmlExtensionsTests.cs
+++ b/tests/RazorSlices/TextWriterHtmlExtensionsTests.cs
@@ -125,4 +125,86 @@ public class TextWriterHtmlExtensionsTests
         var expected = string.Concat(Enumerable.Repeat("&lt;", 1_000));
         Assert.Equal(expected, writer.ToString());
     }
+
+    private enum SampleStatus
+    {
+        Open = 0,
+        Posted = 1
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteSpanFormattable_WritesOnlyTheFormattedChars_Enum()
+    {
+        var writer = new StringWriter();
+
+        writer.HtmlEncodeAndWriteSpanFormattable(SampleStatus.Open, HtmlEncoder.Default);
+
+        Assert.Equal("Open", writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteSpanFormattable_WritesOnlyTheFormattedChars_Int()
+    {
+        var writer = new StringWriter();
+
+        writer.HtmlEncodeAndWriteSpanFormattable(42, HtmlEncoder.Default);
+
+        Assert.Equal("42", writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteSpanFormattable_DoesNotWriteBufferPadding()
+    {
+        // The rented encode buffer comes from ArrayPool<char>.Shared, whose smallest bucket is 16.
+        // Writing the whole buffer instead of the encoded length appended 12 chars of whatever the
+        // previous renter left behind.
+        var writer = new StringWriter();
+
+        writer.HtmlEncodeAndWriteSpanFormattable(SampleStatus.Open, HtmlEncoder.Default);
+
+        Assert.Equal(4, writer.ToString().Length);
+        Assert.DoesNotContain('\0', writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteSpanFormattable_DoesNotLeakPreviousRenterContent()
+    {
+        // Dirty the shared pool with a long value first, then write a short one. Without the fix
+        // the short write carried the tail of the long one into the output.
+        var warmup = new StringWriter();
+        warmup.HtmlEncodeAndWriteSpanFormattable(1234567890123456789L, HtmlEncoder.Default);
+
+        var writer = new StringWriter();
+        writer.HtmlEncodeAndWriteSpanFormattable(SampleStatus.Posted, HtmlEncoder.Default);
+
+        Assert.Equal("Posted", writer.ToString());
+    }
+
+    [Fact]
+    public void HtmlEncodeAndWriteSpanFormattable_StillEncodesHtml()
+    {
+        var writer = new StringWriter();
+
+        writer.HtmlEncodeAndWriteSpanFormattable(new HtmlishFormattable(), HtmlEncoder.Default);
+
+        Assert.Equal("a&lt;b&gt;c", writer.ToString());
+    }
+
+    private readonly struct HtmlishFormattable : ISpanFormattable
+    {
+        public string ToString(string? format, IFormatProvider? formatProvider) => "a<b>c";
+
+        public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+        {
+            const string value = "a<b>c";
+            if (destination.Length < value.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+            value.AsSpan().CopyTo(destination);
+            charsWritten = value.Length;
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #135.

`HtmlEncodeAndWriteSpanFormattable` on the `TextWriter` path wrote the whole rented encode buffer instead of the part it had filled. `encodeBuffer` comes from `ArrayPool<char>.Shared`, whose smallest bucket is 16 chars, so writing `Open` emitted 16 characters: the value plus 12 characters of pooled memory. When the pool hands back a used array, those characters are text from an earlier render, so one response can carry fragments of another.

Two changes, both in `src/RazorSlices/TextWriterHtmlExtensions.cs`:

- The final flush writes `encodeBuffer.AsSpan()[..waitingToWrite]`. The in-loop flush a few lines above already did this; only the last one did not.
- `TryHtmlEncodeAndWriteSpanFormattableSmall` encodes `formatBuffer[..charsWritten]` rather than the whole stack buffer, and writes the encoded chars before returning `true`. It was returning `true` to say it had handled the write while writing nothing, so any value it accepted was dropped. Today it almost always returns `false` because encoding the uninitialised tail overflows the destination, which is why the dropped output has not been noticed.

The `PipeWriter` versions and the UTF-8 helpers already slice by the written length, so nothing there changes.

### Tests

Five cases added to `TextWriterHtmlExtensionsTests`:

- an enum and an `int` write only their formatted characters
- the output has no buffer padding and no `\0`
- a short write after a long one does not carry the previous value's tail
- HTML encoding still happens for a value containing `<` and `>` (this one covers the small path actually writing)

All five fail on `main` and pass with the change. The 28 existing tests pass either way, which is why this went unnoticed.

### Notes

`RazorSlice.PushWriter` swaps the `PipeWriter` for a `TextWriter`, so in an app this surfaces inside templated Razor delegates (`@<text>` slots) and looks fine everywhere else. We found it as a status badge rendering `Openned out.` and `Open0817T114126Z` on alternate requests.

Happy to split the small-path change into its own commit or drop it from this PR if you would rather take the one-line flush fix on its own.

---

Prepared with AI assistance (Claude). I ran the suite locally against `main` in both directions before opening this.
