### PR TITLE
Bump patch version to 0.11.3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <VersionPrefix>0.11.2</VersionPrefix>
+    <VersionPrefix>0.11.3</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->


### PR DESCRIPTION
## Summary

- bump `VersionPrefix` from `0.11.2` to `0.11.3`
- prepare the patch release containing the `TextWriter` pooled-buffer fix from #136

## Validation

- confirmed the ship-candidate `PackageVersion` resolves to `0.11.3`