### PR TITLE
Support writing `ReadOnlyMemory<byte>` directly

### DIFF
--- a/src/RazorSlices/RazorSlice.Write.cs
+++ b/src/RazorSlices/RazorSlice.Write.cs
@@ -113,6 +113,16 @@ public partial class RazorSlice
     /// all matching Razor expressions in your .cshtml file.
     /// </remarks>
     /// <param name="value">The value to write to the output.</param>
+    protected void Write(ReadOnlyMemory<byte> value) => Write(value.Span);
+
+    /// <summary>
+    /// Writes a buffer of UTF8 bytes to the output after HTML encoding it.
+    /// </summary>
+    /// <remarks>
+    /// You generally shouldn't call this method directly. The Razor compiler will emit the appropriate calls to this method for
+    /// all matching Razor expressions in your .cshtml file.
+    /// </remarks>
+    /// <param name="value">The value to write to the output.</param>
     protected void Write(ReadOnlySpan<byte> value)
     {
         if (value.Length == 0)

--- a/tests/RazorSlices/RazorSliceWriteTests.cs
+++ b/tests/RazorSlices/RazorSliceWriteTests.cs
@@ -1,0 +1,28 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
+
+namespace RazorSlices.Tests;
+
+public class RazorSliceWriteTests
+{
+    [Fact]
+    public async Task WriteReadOnlyMemoryByte_WritesHtmlEncodedUtf8Text()
+    {
+        var value = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("Héllo <Wörld> 日本語"));
+        var slice = new WriteReadOnlyMemoryByteSlice(value);
+
+        var result = await slice.RenderAsync(HtmlEncoder.Create(UnicodeRanges.All));
+
+        Assert.Equal("Héllo &lt;Wörld&gt; 日本語", result);
+    }
+
+    private sealed class WriteReadOnlyMemoryByteSlice(ReadOnlyMemory<byte> value) : RazorSlice
+    {
+        public override Task ExecuteAsync()
+        {
+            Write(value);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `Write(ReadOnlyMemory<byte>)` overload that delegates to the existing UTF-8 span rendering path
- cover multibyte UTF-8 decoding and HTML encoding with a regression test

Fixes #138

## Testing
- `dotnet test tests\RazorSlices\RazorSlices.Tests.csproj --no-restore --nologo`