### PR TITLE
Parallelize CI publish tests

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -51,6 +51,14 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-restore --no-build --filter "FullyQualifiedName!~RazorSlices.Samples.WebApp.PublishTests.PublishSample"
 
+    - name: Publish samples
+      run: |
+        for projectPath in ./samples/**/*.csproj ; do
+          projectFileName=${projectPath##*/}
+          projectName=${projectFileName%.*}
+          dotnet publish "$projectPath" --output "./artifacts/$projectName" --framework net8.0 --configuration Release --verbosity normal
+        done;
+
     - name: Build benchmarks
       run: dotnet build --configuration Benchmarks
 

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -8,18 +8,19 @@ on:
         type: boolean
         default: false
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+  DOTNET_ADD_GLOBAL_TOOLS_TO_PATH: false
+  DOTNET_MULTILEVEL_LOOKUP: 0
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Build & Test
-    env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: 1
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-      DOTNET_NOLOGO: true
-      DOTNET_GENERATE_ASPNET_CERTIFICATE: false
-      DOTNET_ADD_GLOBAL_TOOLS_TO_PATH: false
-      DOTNET_MULTILEVEL_LOOKUP: 0
-      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
 
     steps:
     - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
@@ -46,19 +47,10 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore -p:BuildNumber=$BUILD_NUMBER -p:SourceRevisionId=$GITHUB_SHA -p:ContinuousIntegrationBuild=true
 
+    # PublishSample scenarios run in the parallel matrix below.
     - name: Test
-      run: dotnet test --configuration Release --no-restore --no-build
+      run: dotnet test --configuration Release --no-restore --no-build --filter "FullyQualifiedName!~RazorSlices.Samples.WebApp.PublishTests.PublishSample"
 
-    - name: Publish samples
-      run: |
-        for projectPath in ./samples/**/*.csproj ; do
-          for tfm in "net8.0"; do
-            projectFileName=${projectPath##*/}
-            projectName=${projectFileName%.*}
-            dotnet publish "$projectPath" --output "./artifacts/$projectName" --framework $tfm --configuration Release --verbosity normal
-          done;
-        done;
-    
     - name: Build benchmarks
       run: dotnet build --configuration Benchmarks
 
@@ -75,3 +67,37 @@ jobs:
         name: nupkg
         path: ./artifacts/**/*.nupkg
         retention-days: 5
+
+  publish-tests:
+    runs-on: ubuntu-latest
+    name: Publish ${{ matrix.project }} (${{ matrix.framework }})
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+        - WebApp
+        - PagesAndSlices
+        framework:
+        - net8.0
+        - net9.0
+        - net10.0
+
+    steps:
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+    - name: Install .NET SDKs/runtimes
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      with:
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
+          11.0.x
+
+    - name: Publish and verify
+      # %22 encodes the quotes around xUnit theory argument values for VSTest.
+      run: >-
+        dotnet test tests/Samples.WebApp.PublishTests/Samples.WebApp.PublishTests.csproj
+        --configuration Release
+        --filter "FullyQualifiedName~RazorSlices.Samples.WebApp.PublishTests.PublishSample&DisplayName~projectName: %22${{ matrix.project }}%22&DisplayName~${{ matrix.framework }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build & Test PR

--- a/tests/Samples.WebApp.PublishTests/DotNetCli.cs
+++ b/tests/Samples.WebApp.PublishTests/DotNetCli.cs
@@ -7,7 +7,7 @@ namespace RazorSlices.Samples.WebApp.PublishTests;
 public class DotNetCli
 {
     private static readonly string _fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
-    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan _timeout = TimeSpan.FromMinutes(5);
 
     public static string Clean(IEnumerable<string> args)
     {
@@ -60,21 +60,22 @@ public class DotNetCli
             throw new InvalidOperationException($"dotnet {commandName} failed");
         }
 
-        process.WaitForExit();
+        var stdOutTask = process.StandardOutput.ReadToEndAsync();
+        var stdErrTask = process.StandardError.ReadToEndAsync();
 
         if (!process.WaitForExit(_timeout))
         {
-            process.Kill();
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
 
             throw new InvalidOperationException($"dotnet {commandName} took longer than the allowed time of {_timeout}");
         }
 
-        var stdOut = process.StandardOutput.ReadToEnd();
+        var stdOut = stdOutTask.GetAwaiter().GetResult();
+        var stdErr = stdErrTask.GetAwaiter().GetResult();
 
         if (process.ExitCode != 0)
         {
-            var stdErr = process.StandardError.ReadToEnd();
-
             throw new InvalidOperationException($"""
                 dotnet {commandName} failed on exit ({process.ExitCode})
                 Error:  {stdErr}

--- a/tests/Samples.WebApp.PublishTests/DotNetCli.cs
+++ b/tests/Samples.WebApp.PublishTests/DotNetCli.cs
@@ -26,7 +26,8 @@ public class DotNetCli
             projectPath,
             "--configuration", "Release",
             "--output", outputDir,
-            "--no-restore"
+            "--no-restore",
+            "--disable-build-servers"
         };
         return RunCommand("pack", args, testOutput);
     }


### PR DESCRIPTION
## Summary
- run the six runtime-specific sample publish tests in a project/framework matrix
- retain the existing portable net8.0 publish validation for every sample project
- prevent redirected `dotnet` child processes and build servers from holding test output pipes open
- cancel superseded PR workflow runs

## Rationale
The original workflow spent about 15 minutes of its 17.5-minute duration waiting for the package-content test process to close redirected output. The process helper now drains output concurrently and disables build servers for packing, while the runtime-specific publish cases run in parallel.

## Validation
- all seven publish tests are selected exactly once across the main test job and matrix filters
- all regular tests, portable sample publishes, and six matrix publish checks pass
- package-content verification completes in seconds from a cold build-server state
- measured CI improved from 17m 35s to 2m 29s with the full original publish coverage retained